### PR TITLE
Add user passwords to enable login directly to apidoc

### DIFF
--- a/api/app/db/UserPasswordDao.scala
+++ b/api/app/db/UserPasswordDao.scala
@@ -1,0 +1,169 @@
+package db
+
+import lib.Constants
+import anorm._
+import play.api.db._
+import play.api.Play.current
+import play.api.libs.json._
+import java.util.UUID
+import org.mindrot.jbcrypt.BCrypt
+import org.apache.commons.codec.binary.Base64
+
+private[db] case class HashedPassword(hash: String, salt: String)
+
+sealed trait PasswordAlgorithm {
+
+  /**
+   * Uniquely identifies this password algorithm
+   */
+  def key: String
+
+  /**
+   * Hashes the provided String, returning the hashed value
+   */
+  def hash(password: String): HashedPassword
+
+  /**
+   * Check if a cleartext password is valid
+   */
+  def check(candidate: String, hashed: String): Boolean
+
+}
+
+case class BcryptPasswordAlgorithm(override val key: String) extends PasswordAlgorithm {
+
+  private val LogRounds = 10
+
+  override def hash(password: String): HashedPassword = {
+    val salt = BCrypt.gensalt(LogRounds)
+    HashedPassword(
+      salt = salt,
+      hash = BCrypt.hashpw(password, salt)
+    )
+  }
+
+  override def check(candidate: String, hashed: String): Boolean = {
+    BCrypt.checkpw(candidate, hashed)
+  }
+
+}
+
+/**
+ * Used only when fetching unknown keys from DB but will fail if you try to hash
+ */
+private[db] case class UnknownPasswordAlgorithm(override val key: String) extends PasswordAlgorithm {
+
+  override def hash(password: String): HashedPassword = {
+    sys.error("Unsupported operation for uknown password hash")
+  }
+
+  override def check(candidate: String, hashed: String) = false
+
+}
+
+object PasswordAlgorithm {
+
+  val All = Seq(
+    new BcryptPasswordAlgorithm("bcrypt"),
+    new UnknownPasswordAlgorithm("unknown")
+  )
+
+  val Latest = fromString("bcrypt").getOrElse {
+    sys.error("Could not find latest algorithm")
+  }
+
+  val Unknown = fromString("unknown").getOrElse {
+    sys.error("Could not find unknown algorithm")
+  }
+
+  def fromString(value: String): Option[PasswordAlgorithm] = {
+    All.find(_.key == value)
+  }
+
+}
+
+case class UserPassword(guid: UUID, userGuid: UUID, algorithm: PasswordAlgorithm, hash: String)
+
+object UserPasswordDao {
+
+  private val BaseQuery = """
+    select guid::varchar, user_guid::varchar, algorithm_key, hash
+      from user_passwords
+     where deleted_at is null
+  """
+
+  private val InsertQuery = """
+    insert into user_passwords
+    (guid, user_guid, algorithm_key, hash, created_by_guid, updated_by_guid)
+    values
+    ({guid}::uuid, {user_guid}::uuid, {algorithm_key}, {hash}, {created_by_guid}::uuid, {updated_by_guid}::uuid)
+  """
+
+  private val SoftDeleteByUserGuidQuery = """
+    update user_passwords
+       set deleted_by_guid = {deleted_by_guid}::uuid, deleted_at = now()
+     where user_guid = {user_guid}::uuid
+       and deleted_at is null
+  """
+
+  def create(user: User, userGuid: UUID, cleartextPassword: String) {
+    val guid = UUID.randomUUID
+    val algorithm = PasswordAlgorithm.Latest
+    val hashedPassword = algorithm.hash(cleartextPassword)
+
+    DB.withTransaction { implicit c =>
+      softDeleteByUserGuid(c, user, userGuid)
+
+      SQL(InsertQuery).on(
+        'guid -> guid,
+        'user_guid -> userGuid,
+        'algorithm_key -> algorithm.key,
+        'hash -> new String(Base64.encodeBase64(hashedPassword.hash.getBytes)),
+        'created_by_guid -> user.guid,
+        'updated_by_guid -> user.guid
+      ).execute()
+    }
+  }
+
+  def softDeleteByUserGuid(user: User, userGuid: UUID) {
+    DB.withConnection { implicit c =>
+      softDeleteByUserGuid(c, user, userGuid)
+    }
+  }
+
+  private def softDeleteByUserGuid(implicit connection: java.sql.Connection, deletedBy: User, userGuid: UUID) {
+    SQL(SoftDeleteByUserGuidQuery).on('deleted_by_guid -> deletedBy.guid, 'user_guid -> userGuid).execute()
+  }
+
+  def isValid(userGuid: UUID, cleartextPassword: String): Boolean = {
+    findByUserGuid(userGuid) match {
+      case None => false
+      case Some(up: UserPassword) => {
+        up.algorithm.check(cleartextPassword, up.hash)
+      }
+    }
+  }
+
+  private[db] def findByUserGuid(userGuid: UUID): Option[UserPassword] = {
+    val sql = Seq(
+      Some(BaseQuery.trim),
+      Some("and user_passwords.user_guid = {guid}::uuid")
+    ).flatten.mkString("\n   ")
+
+    val bind = Seq[Option[NamedParameter]](
+      Some('guid -> userGuid)
+    ).flatten
+
+    DB.withConnection { implicit c =>
+      SQL(sql).on(bind: _*)().toList.map { row =>
+        UserPassword(
+          guid = UUID.fromString(row[String]("guid")),
+          userGuid = UUID.fromString(row[String]("user_guid")),
+          algorithm = PasswordAlgorithm.fromString(row[String]("algorithm_key")).getOrElse(PasswordAlgorithm.Unknown),
+          hash = new String(Base64.decodeBase64(row[String]("hash").getBytes))
+        )
+      }.toSeq.headOption
+    }
+  }
+
+}

--- a/api/test/db/UserPasswordDaoSpec.scala
+++ b/api/test/db/UserPasswordDaoSpec.scala
@@ -1,0 +1,57 @@
+package db
+
+import org.scalatest.FlatSpec
+import org.junit.Assert._
+import java.util.UUID
+
+class UserPasswordDaoSpec extends FlatSpec {
+
+  new play.core.StaticApplication(new java.io.File("."))
+
+  private val user = UserDao.upsert("michael@mailinator.com")
+  private val userGuid = UUID.fromString(user.guid)
+
+  it should "have distinct keys for all algorithms" in {
+    val keys = PasswordAlgorithm.All.map(_.key.toLowerCase)
+    assertEquals(keys, keys.distinct.sorted)
+  }
+
+  it should "findByUserGuid" in {
+    UserPasswordDao.softDeleteByUserGuid(user, userGuid)
+
+    assertEquals(None, UserPasswordDao.findByUserGuid(userGuid))
+
+    UserPasswordDao.create(user, userGuid, "password")
+
+    val up = UserPasswordDao.findByUserGuid(userGuid).get
+    assertEquals(up.userGuid.toString, user.guid)
+    assertEquals(up.algorithm, PasswordAlgorithm.Latest)
+  }
+
+  it should "validate matching passwords" in {
+    UserPasswordDao.create(user, userGuid, "password")
+    assertEquals(UserPasswordDao.isValid(userGuid, "password"), true)
+    assertEquals(UserPasswordDao.isValid(userGuid, "password2"), false)
+    assertEquals(UserPasswordDao.isValid(userGuid, "test"), false)
+    assertEquals(UserPasswordDao.isValid(userGuid, ""), false)
+
+    UserPasswordDao.create(user, userGuid, "test")
+    assertEquals(UserPasswordDao.isValid(userGuid, "password"), false)
+    assertEquals(UserPasswordDao.isValid(userGuid, "password2"), false)
+    assertEquals(UserPasswordDao.isValid(userGuid, "test"), true)
+    assertEquals(UserPasswordDao.isValid(userGuid, ""), false)
+  }
+
+  it should "hash the password" in {
+    UserPasswordDao.create(user, userGuid, "password")
+    val up = UserPasswordDao.findByUserGuid(userGuid).get
+    assertEquals(-1, up.hash.indexOf("password"))
+  }
+
+  it should "generates unique hashes, even for same password" in {
+    PasswordAlgorithm.All.filter { _ != PasswordAlgorithm.Unknown }.foreach { algo =>
+      assertNotEquals(algo.hash("password"), algo.hash("password"))
+    }
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,10 @@ lazy val api = project
   .settings(commonSettings: _*)
   .settings(commonPlaySettings: _*)
   .settings(
-    version := "1.0-SNAPSHOT"
+    version := "1.0-SNAPSHOT",
+    libraryDependencies ++= Seq(
+      "org.mindrot"          %  "jbcrypt"                 % "0.3m"
+    )
   )
 
 lazy val www = project

--- a/schema/scripts/20140617-081903.sql
+++ b/schema/scripts/20140617-081903.sql
@@ -1,0 +1,28 @@
+drop table if exists user_passwords;
+
+create table user_passwords (
+  guid                    uuid not null primary key,
+  user_guid               uuid not null references users,
+  algorithm_key           text not null,
+  hash                    text not null
+);
+
+select schema_evolution_manager.create_basic_audit_data('public', 'user_passwords');
+
+create index on user_passwords(user_guid);
+create unique index user_passwords_user_guid_not_deleted_un_idx on user_passwords(user_guid) where deleted_at is null;
+
+comment on table user_passwords is '
+  An immutable store of hashed user passwords. When a new password is created,
+  we soft delete the old password and create a new one. A user can have at most
+  1 active password at any time (enforced by a unique constraint)
+';
+
+comment on column user_passwords.algorithm_key is '
+  A key identifying the algorithm_key / version of hashing we used
+  for this particular password.
+';
+
+comment on column user_passwords.hash is '
+  Base64 encoded hash of the password
+';


### PR DESCRIPTION
- passwords are hashed with bcrypt
- record algorithm version along with password to
  allow future changes
- each user can have at most one password, but passwords themselves are immutable in DB
- passwords stored in a separate table: user_passwords
