### PR TITLE
Infer path parameter type if the param is defined on the model

### DIFF
--- a/core/src/main/scala/core/ServiceDescription.scala
+++ b/core/src/main/scala/core/ServiceDescription.scala
@@ -100,7 +100,7 @@ object Operation {
     val internalParamNames: Set[String] = internalParams.map(_.name).toSet
 
     // Capture any path parameters that were not explicitly annotated
-    val pathParameters = internal.namedParameters.filter { name => !internalParamNames.contains(name) }.map { Parameter.fromPath(_) }
+    val pathParameters = internal.namedParameters.filter { name => !internalParamNames.contains(name) }.map { Parameter.fromPath(model, _) }
 
     Operation(model = model,
               method = method,
@@ -266,9 +266,19 @@ object ParameterLocation {
 
 object Parameter {
 
-  def fromPath(name: String): Parameter = {
+  def fromPath(model: Model, name: String): Parameter = {
+    val datatype = model.fields.find(_.name == name) match {
+      case None => Datatype.StringType
+      case Some(f: Field) => {
+        f.fieldtype match {
+          case ft: PrimitiveFieldType => ft.datatype
+          case _ => Datatype.StringType
+        }
+      }
+    }
+
     Parameter(name = name,
-              paramtype = PrimitiveParameterType(Datatype.StringType),
+              paramtype = PrimitiveParameterType(datatype),
               location = ParameterLocation.Path,
               required = true)
   }

--- a/core/src/test/scala/core/ServiceDescriptionValidatorSpec.scala
+++ b/core/src/test/scala/core/ServiceDescriptionValidatorSpec.scala
@@ -166,7 +166,41 @@ class ServiceDescriptionValidatorSpec extends FunSpec with Matchers {
     val op = validator.serviceDescription.get.resources.head.operations.head
     op.parameters.map(_.name) should be(Seq("guid"))
     val guid = op.parameters.head
-    guid.paramtype should be(PrimitiveParameterType(Datatype.StringType)) // TODO: Should we look up the field and infer UUID type?
+    guid.paramtype should be(PrimitiveParameterType(Datatype.UuidType))
+  }
+
+  it("infers datatype for a path parameter from the associated model") {
+
+    val json = """
+    {
+      "base_url": "http://localhost:9000",
+      "name": "Api Doc",
+      "models": {
+        "user": {
+          "fields": [
+            { "name": "id", "type": "long" }
+          ]
+        }
+      },
+      "resources": {
+       "user": {
+          "operations": [
+            {
+              "method": "DELETE",
+              "path": "/:id"
+            }
+          ]
+        }
+      }
+    }
+    """
+
+    val validator = ServiceDescriptionValidator(json)
+    validator.errors.mkString("") should be("")
+    val op = validator.serviceDescription.get.resources.head.operations.head
+    val idParam = op.parameters.head
+    idParam.name should be("id")
+    idParam.paramtype.asInstanceOf[PrimitiveParameterType].datatype.name should be("long")
   }
 
 }

--- a/core/src/test/scala/core/generator/Play2RouteGeneratorSpec.scala
+++ b/core/src/test/scala/core/generator/Play2RouteGeneratorSpec.scala
@@ -45,7 +45,7 @@ class Play2RouteGeneratorSpec extends FunSpec with ShouldMatchers {
       r.verb should be("GET")
       r.url should be("/users/:guid")
       r.method should be("controllers.Users.getByGuid")
-      r.params.mkString(", ") should be("guid: String")
+      r.params.mkString(", ") should be("guid: java.util.UUID")
     }
 
     it("POST w/ default path, no parameters") {
@@ -63,7 +63,7 @@ class Play2RouteGeneratorSpec extends FunSpec with ShouldMatchers {
       r.verb should be("PUT")
       r.url should be("/users/:guid")
       r.method should be("controllers.Users.putByGuid")
-      r.params.mkString(", ") should be("guid: String")
+      r.params.mkString(", ") should be("guid: java.util.UUID")
     }
   }
 
@@ -78,7 +78,7 @@ class Play2RouteGeneratorSpec extends FunSpec with ShouldMatchers {
       r.verb should be("POST")
       r.url should be("/membership_requests/:guid/accept")
       r.method should be("controllers.MembershipRequests.postAcceptByGuid")
-      r.params.mkString(", ") should be("guid: String")
+      r.params.mkString(", ") should be("guid: java.util.UUID")
     }
   }
 


### PR DESCRIPTION
- Means a path like /items/:id will correct infer type Long
  and /items/:guid would infer UUID if those fields are defined
  on the item model
