### PR TITLE
Added an optional 'interface' property for Operation.

### DIFF
--- a/core/src/main/scala/core/InternalServiceDescription.scala
+++ b/core/src/main/scala/core/InternalServiceDescription.scala
@@ -80,6 +80,7 @@ case class InternalResource(modelName: Option[String],
 
 case class InternalOperation(method: Option[String],
                              path: String,
+                             interface: Option[String],
                              description: Option[String],
                              namedParameters: Seq[String],
                              parameters: Seq[InternalParameter],
@@ -204,6 +205,7 @@ object InternalOperation {
 
     InternalOperation(method = (json \ "method").asOpt[String].map(_.toUpperCase),
                       path = path,
+                      interface = (json \ "interface").asOpt[String],
                       description = (json \ "description").asOpt[String],
                       responses = responses,
                       namedParameters = namedParameters,

--- a/core/src/main/scala/core/ServiceDescription.scala
+++ b/core/src/main/scala/core/ServiceDescription.scala
@@ -62,6 +62,7 @@ case class Resource(model: Model,
 case class Operation(model: Model,
                      method: String,
                      path: String,
+                     interface: Option[String],
                      description: Option[String],
                      parameters: Seq[Parameter],
                      responses: Seq[Response]) {
@@ -105,6 +106,7 @@ object Operation {
     Operation(model = model,
               method = method,
               path = internal.path,
+              interface = internal.interface,
               description = internal.description,
               parameters = pathParameters ++ internalParams,
               responses = internal.responses.map { Response(_) })

--- a/core/src/main/scala/core/generator/ScalaServiceDescription.scala
+++ b/core/src/main/scala/core/generator/ScalaServiceDescription.scala
@@ -94,7 +94,7 @@ class ScalaOperation(model: ScalaModel, operation: Operation, resource: ScalaRes
 
   lazy val formParameters = parameters.filter { _.location == ParameterLocation.Form }
 
-  val name: String = GeneratorUtil.urlToMethodName(resource.path, operation.method, operation.path)
+  val name: String = operation.interface.getOrElse(GeneratorUtil.urlToMethodName(resource.path, operation.method, operation.path))
 
   val argList: String = ScalaUtil.fieldsToArgList(parameters.map(_.definition))
 


### PR DESCRIPTION
When available, this property should supersede the generated name for the Scala operation.

Example:

```
"resources": [
  {
    "model": "organization",
    "operations": [
      {
        "method": "POST",
        "interface": "createOrganization",
        "description": "Create a new organization.",
        "parameters": [ ...
```

Instead of `postOrganizations`, this operation would be called `createOrganization` in the generated Scala client.
