### PR TITLE
No longer allow user to specify 404, 5xx explicitly in api.json

### DIFF
--- a/core/src/main/scala/core/ServiceDescriptionValidator.scala
+++ b/core/src/main/scala/core/ServiceDescriptionValidator.scala
@@ -260,6 +260,24 @@ case class ServiceDescriptionValidator(apiJson: String) {
       Seq.empty
     }
 
+    val typesNotAllowed = Seq(404) // also >= 500
+    val responsesWithDisallowedTypes = if (invalidCodes.isEmpty) {
+      internalServiceDescription.get.resources.filter { !_.modelName.isEmpty }.flatMap { resource =>
+        resource.operations.flatMap { op =>
+          op.responses.find { r => typesNotAllowed.contains(r.code.toInt) || r.code.toInt >= 500 } match {
+            case None => {
+              None
+            }
+            case Some(r) => {
+              Some(s"Resource[${resource.modelName.get}] ${op.label} has a response with code[${r.code}] - this code cannot be explicitly specified")
+            }
+          }
+        }
+      }
+    } else {
+      Seq.empty
+    }
+
     val typesRequiringUnit = Seq(204, 304, 404)
     val noContentWithTypes = if (invalidCodes.isEmpty) {
       internalServiceDescription.get.resources.filter { !_.modelName.isEmpty }.flatMap { resource =>
@@ -273,7 +291,7 @@ case class ServiceDescriptionValidator(apiJson: String) {
       Seq.empty
     }
 
-    invalidCodes ++ missingTypes ++ mixed2xxResponseTypes ++ noContentWithTypes
+    invalidCodes ++ missingTypes ++ mixed2xxResponseTypes ++ responsesWithDisallowedTypes ++ noContentWithTypes
   }
 
   private lazy val ValidDatatypes = Datatype.All.map(_.name).sorted.mkString(" ")

--- a/core/src/main/scala/core/generator/ScalaServiceDescription.scala
+++ b/core/src/main/scala/core/generator/ScalaServiceDescription.scala
@@ -116,7 +116,7 @@ class ScalaResponse(packageName: String, method: String, response: Response) {
   val scalaType: String = underscoreToInitCap(response.datatype)
   val isUnit = scalaType == "Unit"
   val isMultiple = response.multiple
-  val isOption = !isMultiple && !GeneratorUtil.isJsonDocumentMethod(method)
+  val isOption = !GeneratorUtil.isJsonDocumentMethod(method) && !isMultiple
 
   val code = response.code
   val isSuccess = code >= 200 && code < 300

--- a/core/src/test/scala/core/ServiceDescriptionResponsesSpec.scala
+++ b/core/src/test/scala/core/ServiceDescriptionResponsesSpec.scala
@@ -30,7 +30,7 @@ class ServiceDescriptionResponsesSpec extends FunSpec with Matchers {
   """
 
   it("Returns error message if user specifies non Unit Response type") {
-    Seq(204, 304, 404).foreach { code =>
+    Seq(204, 304).foreach { code =>
       val json = baseJson.format(s""", "responses": { "$code": { "type": "user" } } """)
       val validator = ServiceDescriptionValidator(json)
       validator.errors.mkString("") should be(s"Resource[user] DELETE /users/:id Responses w/ code[$code] must return unit and not[user]")
@@ -44,6 +44,14 @@ class ServiceDescriptionResponsesSpec extends FunSpec with Matchers {
     val response = validator.serviceDescription.get.resources.head.operations.head.responses.head
     response.code should be(204)
     response.datatype should be("unit")
+  }
+
+  it("does not allow explicit definition of 404, 5xx status codes") {
+    Seq(404, 500, 501, 502).foreach { code =>
+      val json = baseJson.format(s""", "responses": { "$code": { "type": "unit" } } """)
+      val validator = ServiceDescriptionValidator(json)
+      validator.errors.mkString("") should be(s"Resource[user] DELETE /users/:id has a response with code[$code] - this code cannot be explicitly specified")
+    }
   }
 
 }

--- a/core/src/test/scala/core/generator/Play2ClientGeneratorSpec.scala
+++ b/core/src/test/scala/core/generator/Play2ClientGeneratorSpec.scala
@@ -1,14 +1,12 @@
 package core.generator
 
-import core.TestHelper
+import core.{ ServiceDescriptionValidator, TestHelper }
 import org.scalatest.{ ShouldMatchers, FunSpec }
 
 class Play2ClientGeneratorSpec extends FunSpec with ShouldMatchers {
 
-  private val Path = "api/api.json"
-  private lazy val service = TestHelper.parseFile(Path).serviceDescription.get
-
   it("errorTypeClass") {
+    val service = TestHelper.parseFile("api/api.json").serviceDescription.get
     val ssd = new ScalaServiceDescription(service)
     val resource = ssd.resources.find(_.model.name == "Organization").get
     val operation = resource.operations.find(_.method == "POST").get
@@ -22,6 +20,42 @@ case class ErrorsResponse(response: play.api.libs.ws.WSResponse) extends Excepti
 }
 """.trim
     Play2ClientGenerator.errorTypeClass(errorResponse).trim should be(target)
+  }
+
+  it("only generates error wrappers for model classes (not primitives)") {
+    val json = """
+    {
+      "base_url": "http://localhost:9000",
+      "name": "Api Doc",
+      "models": {
+        "user": {
+          "fields": [
+            { "name": "id", "type": "long" }
+          ]
+        }
+      },
+      "resources": {
+        "user": {
+          "operations": [
+            {
+              "method": "GET",
+              "path": "/:id",
+              "responses": {
+                "200": { "type": "user" },
+                "409": { "type": "unit" }
+              }
+            }
+          ]
+        }
+      }
+    }
+
+    """
+
+    val validator = ServiceDescriptionValidator(json)
+    validator.errors.mkString("") should be("")
+    val ssd = new ScalaServiceDescription(validator.serviceDescription.get)
+    Play2ClientGenerator.errors(ssd) should be(None)
   }
 
 }


### PR DESCRIPTION
404, 5xx have specific meanings in api.json, including the desire for client code to be simple We want to make sure that 404 does not include any data - errors returning data can use different response codes.

This change makes it a validation error to include an explicit 404 or 5xx response code.

For 404s:
- we add a 404 check for all GET requests
- if method returns an array, 404 returns Nil
- if method returns an instance, return type will return Option[Instance]; 404 returns None
