### PR TITLE
Dev setup fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ Installing Docker on mac
 Developing
 ==========
 
-You'll need to get the api schema into your dev database; to do that:
+You'll need to get the api schema into your dev postgresql database.
 
 $ psql
 psql> CREATE DATABASE api;
+
+Then you'll need to create the database schema using schema evolution manager.  Installation instructions are [here](https://github.com/gilt/schema-evolution-manager#installation).
 
 $ cd /web/apidoc/schema
 $ ./dev.rb

--- a/schema/dev.rb
+++ b/schema/dev.rb
@@ -6,5 +6,6 @@
 #
 
 command = "sem-apply --host localhost --user web --name api"
-puts command
-system(command)
+puts "Executing: " + command
+`#{command}`
+


### PR DESCRIPTION
Improving instructions are database setup for apidoc.  Using backticks instead.

of system so the dev script so output will hit the console (instead of failing
silently).
