### PR TITLE
Simplify avro schemas for fields of type model

### DIFF
--- a/core/src/main/scala/core/generator/AvroSchemas.scala
+++ b/core/src/main/scala/core/generator/AvroSchemas.scala
@@ -42,6 +42,7 @@ s"""{
 
   private def genType(t: AvroType, knownTypes: MSet[String]): String = t match {
     case p: AvroPrimitiveType => s""""${p.name}""""
+    case AvroModelType(modelName) => s""""${modelName}""""
     case AvroRecordType(model) => genModel(model, knownTypes)
     case AvroEnumType(symbols) => s""""enum", "symbols": [${symbols.mkString("\"","\", \"","\"")}]"""
     case AvroArrayType(itemType) => s""""array", "items": ${genType(itemType, knownTypes)}"""

--- a/core/src/test/resources/avro/circular.avsc
+++ b/core/src/test/resources/avro/circular.avsc
@@ -1,0 +1,9 @@
+{
+  "type": "record",
+  "name": "category",
+  "namespace": "apidoc",
+  "fields": [
+    {"name": "uuid", "type": {"namespace": "java.util", "type": "fixed", "size": 16, "name": "UUID"}},
+    {"name": "parent", "type": "category"}
+  ]
+}

--- a/core/src/test/resources/avro/circular.json
+++ b/core/src/test/resources/avro/circular.json
@@ -1,0 +1,12 @@
+{
+  "base_url": "http://localhost:9000",
+  "name": "Api Doc",
+  "models": {
+    "category": {
+      "fields": [
+        { "name": "uuid", "type": "uuid" },
+        { "name": "parent", "type": "category"}
+      ]
+    }
+  }
+}

--- a/core/src/test/resources/avro/example.avsc
+++ b/core/src/test/resources/avro/example.avsc
@@ -45,16 +45,7 @@
              {"name": "scale", "type": "int"}
           ]
          }, "default": "0.0"},
-    {"name": "last_purchase", "type": [{
-          "type": "record",
-          "name": "purchase",
-          "namespace": "apidoc",
-          "fields": [
-             { "name": "product", "type": "string" },
-             { "name": "price", "type": "java.math.BigDecimal" }
-          ]
-        }, "null"]
-    },
+    {"name": "last_purchase", "type": ["purchase", "null"]},
     {"name": "referring_user_uuid", "type": ["java.util.UUID", "null"]},
     {"name": "adhoc", "type": "map", "values": "string"}
   ]

--- a/core/src/test/scala/core/generator/AvroGeneratorSpec.scala
+++ b/core/src/test/scala/core/generator/AvroGeneratorSpec.scala
@@ -9,8 +9,17 @@ class AvroGeneratorSpec extends FunSpec with ShouldMatchers {
 
     it("should generate correct Avro schema") {
       val schema = AvroSchemas(TestHelper.readFile("core/src/test/resources/avro/example.json"))
-      //println(schema)
+      // println(schema)
       cleanws(schema) should be(cleanws(TestHelper.readFile("core/src/test/resources/avro/example.avsc")))
+    }
+
+  }
+
+  describe("for example json with circular references") {
+
+    it("should generate correct Avro schema") {
+      val schema = AvroSchemas(TestHelper.readFile("core/src/test/resources/avro/circular.json"))
+      cleanws(schema) should be(cleanws(TestHelper.readFile("core/src/test/resources/avro/circular.avsc")))
     }
 
   }


### PR DESCRIPTION
- Allows us to just reference model record definitions by name
- Provides native support for resolving circular references
