### PR TITLE
Use play.utils.UriEncoding.encodePathSegment to encode path segments.

### DIFF
--- a/core/src/main/scala/core/generator/Play2Util.scala
+++ b/core/src/main/scala/core/generator/Play2Util.scala
@@ -67,7 +67,7 @@ object Play2Util {
   private object PathParamHelper {
     def urlEncode(name: String, d: ScalaDataType): String = {
       d match {
-        case ScalaStringType => s"""java.net.URLEncoder.encode($name, "UTF-8")"""
+        case ScalaStringType => s"""play.utils.UriEncoding.encodePathSegment($name, "UTF-8")"""
         case ScalaIntegerType | ScalaDoubleType | ScalaLongType | ScalaBooleanType | ScalaDecimalType | ScalaUuidType => name
         case t => {
           sys.error(s"Cannot encode params of type[$t] as path parameters (name: $name)")


### PR DESCRIPTION
java.net.URLEncoder.encode does not encode path parameters correctly, while
it is (mostly) sufficient for query parameters. Use a Play API call which
tries to do the right thing, see the API at
http://www.playframework.com/documentation/2.3.x/api/scala/index.html#play.utils.UriEncoding$

Path segment encoding differs from encoding for other parts of a URI. For
example, the "&" character is permitted in a path segment, but has special
meaning in query parameters. On the other hand, the "/" character cannot appear
in a path segment, as it is the path delimiter, so it must be encoded as "%2F".
These are just two examples of the differences between path segment and query
string encoding; there are other differences too.
