### PR TITLE
fix nasty bug around scala implicits

### DIFF
--- a/core/src/main/scala/core/generator/Play2Json.scala
+++ b/core/src/main/scala/core/generator/Play2Json.scala
@@ -12,8 +12,6 @@ case class Play2Json(serviceName: String) {
   def readers(model: ScalaModel): String = {
     Seq(
       s"implicit def jsonReads${serviceName}${model.name}: play.api.libs.json.Reads[${model.name}] = {",
-      s"  import play.api.libs.json._",
-      s"  import play.api.libs.functional.syntax._",
       fieldReaders(model).indent(2),
       s"}"
     ).mkString("\n")
@@ -59,8 +57,6 @@ case class Play2Json(serviceName: String) {
       case fields => {
         Seq(
           s"implicit def jsonWrites${serviceName}${model.name}: play.api.libs.json.Writes[${model.name}] = {",
-          s"  import play.api.libs.json._",
-          s"  import play.api.libs.functional.syntax._",
           s"  (",
           model.fields.map { field =>
             s"""(__ \\ "${field.originalName}").write[${field.datatype.name}]"""

--- a/core/src/main/scala/core/generator/Play2Models.scala
+++ b/core/src/main/scala/core/generator/Play2Models.scala
@@ -19,21 +19,23 @@ s"""$caseClasses
 
 package ${ssd.packageName}.models {
   package object json {
-    import play.api.libs.json._
+    import play.api.libs.json.__
+    import play.api.libs.json.JsString
+    import play.api.libs.json.Writes
     import play.api.libs.functional.syntax._
 
-    private implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
+    private[${ssd.packageName}] implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
 
-    private implicit val jsonWritesUUID = new Writes[java.util.UUID] {
+    private[${ssd.packageName}] implicit val jsonWritesUUID = new Writes[java.util.UUID] {
       def writes(x: java.util.UUID) = JsString(x.toString)
     }
 
-    private implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
+    private[${ssd.packageName}] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
       import org.joda.time.format.ISODateTimeFormat.dateTimeParser
       dateTimeParser.parseDateTime(str)
     }
 
-    private implicit val jsonWritesJodaDateTime = new Writes[org.joda.time.DateTime] {
+    private[${ssd.packageName}] implicit val jsonWritesJodaDateTime = new Writes[org.joda.time.DateTime] {
       def writes(x: org.joda.time.DateTime) = {
         import org.joda.time.format.ISODateTimeFormat.dateTime
         val str = dateTime.print(x)

--- a/core/src/test/resources/generators/play-2-json-spec-quality-healthcheck-readers.txt
+++ b/core/src/test/resources/generators/play-2-json-spec-quality-healthcheck-readers.txt
@@ -1,5 +1,3 @@
 implicit def jsonReadsQualityHealthcheck: play.api.libs.json.Reads[Healthcheck] = {
-  import play.api.libs.json._
-  import play.api.libs.functional.syntax._
   (__ \ "status").read[String].map { x => new Healthcheck(status = x) }
 }

--- a/core/src/test/resources/generators/play-2-json-spec-quality-plan-readers.txt
+++ b/core/src/test/resources/generators/play-2-json-spec-quality-plan-readers.txt
@@ -1,6 +1,4 @@
 implicit def jsonReadsQualityPlan: play.api.libs.json.Reads[Plan] = {
-  import play.api.libs.json._
-  import play.api.libs.functional.syntax._
   (
     (__ \ "id").read[Long] and
     (__ \ "incident_id").read[Long] and

--- a/core/src/test/resources/generators/play-2-json-spec-quality-plan-writers.txt
+++ b/core/src/test/resources/generators/play-2-json-spec-quality-plan-writers.txt
@@ -1,6 +1,4 @@
 implicit def jsonWritesQualityPlan: play.api.libs.json.Writes[Plan] = {
-  import play.api.libs.json._
-  import play.api.libs.functional.syntax._
   (
     (__ \ "id").write[Long] and
     (__ \ "incident_id").write[Long] and

--- a/core/src/test/resources/generators/play-2-json-spec-readers-quality-plan-writers.txt
+++ b/core/src/test/resources/generators/play-2-json-spec-readers-quality-plan-writers.txt
@@ -1,6 +1,4 @@
 implicit def jsonWritesQualityPlan: play.api.libs.json.Writes[Plan] = {
-  import play.api.libs.json._
-  import play.api.libs.functional.syntax._
   (
     (__ \ "id").write[Long] and
     (__ \ "incident_id").write[Long] and


### PR DESCRIPTION
the current code generator does not generate implicits for writing date
times that work. The compiler does not apply the implicits when they
are private, but it will apply them if they are package private to
the toplevel generated package.

NOTE: making them private to models or json does not fix!
- remove dangerous imports of everything in the play json package.
  just import what is needed
- do not import from the syntax package multiple times
