### PR TITLE
Fix bug using class in the body without capitalize

### DIFF
--- a/core/src/main/scala/core/generator/ScalaServiceDescription.scala
+++ b/core/src/main/scala/core/generator/ScalaServiceDescription.scala
@@ -169,8 +169,9 @@ class ScalaOperation(serviceDescription: ServiceDescription, model: ScalaModel, 
   }
 
   private def bodyClassArg(name: String): String = {
+    val className = ScalaUtil.toClassName(name)
     Seq(
-      Some(s"${Text.initLowerCase(name)}: ${resource.packageName}.models.${name}"),
+      Some(s"${Text.initLowerCase(name)}: ${resource.packageName}.models.${className}"),
       ScalaUtil.fieldsToArgList(parameters.map(_.definition))
     ).flatten.mkString(", ")
   }

--- a/core/src/test/scala/core/generator/ScalaOperationSpec.scala
+++ b/core/src/test/scala/core/generator/ScalaOperationSpec.scala
@@ -1,0 +1,49 @@
+package core.generator
+
+import core.Datatype.IntegerType
+import core._
+import org.scalatest._
+
+class ScalaOperationSpec extends FunSpec with ShouldMatchers {
+
+  private lazy val service = TestHelper.parseFile("reference-api/api.json").serviceDescription.get
+
+  val q1 = new Parameter(
+    "q1",
+    new PrimitiveParameterType(Datatype.DoubleType),
+    ParameterLocation.Query,
+    None, false, false, None, None, None, None)
+
+  it("models as a parameter in the body should use capitalize") {
+    val body = new ModelBody("model")
+    val model = new Model("model", "models", None, Nil)
+    val operation = new Operation(model, "GET", "models", None, Some(body), Seq(q1), Nil)
+    val resource = new Resource(model, "models", Seq(operation))
+
+    val scalaOperation = new ScalaOperation(
+      service,
+      new ScalaModel(service, model),
+      operation,
+      new ScalaResource(service, "test", resource))
+
+    scalaOperation.argList shouldEqual Some("model: test.models.Model, \n  q1: scala.Option[Double] = None\n")
+
+  }
+
+  it("primitive type as a parameter in the body should not use capitalize") {
+    val body = new PrimitiveBody(IntegerType)
+    val model = new Model("model", "models", None, Nil)
+    val operation = new Operation(model, "GET", "models", None, Some(body), Seq(q1), Nil)
+    val resource = new Resource(model, "models", Seq(operation))
+
+    val scalaOperation = new ScalaOperation(
+      service,
+      new ScalaModel(service, model),
+      operation,
+      new ScalaResource(service, "test", resource))
+
+    scalaOperation.argList shouldEqual Some("value: Int, \n  q1: scala.Option[Double] = None\n")
+
+  }
+
+}


### PR DESCRIPTION
Operations with a model as a body type don't capitalize first letter of the type name. 

 The following case:

```
body: {
    type: "stream"
}
```

generates the following error:

```
[error] package.scala:122: type stream is not a member of package com.gilt.svcstream.models
[error]       def putByStreamId(stream: com.gilt.svcstream.models.stream,
```
