### PR TITLE
Display a user's role on the members page.

### DIFF
--- a/www/app/views/members/show.scala.html
+++ b/www/app/views/members/show.scala.html
@@ -20,6 +20,7 @@
            <td>@member.role</td>
            <td>@member.user.email</td>
            <td>@member.user.name</td>
+           <td>@member.role</td>
            @if(isAdmin) {
              <td>
                @if(member.role == lib.Role.Member.key) {


### PR DESCRIPTION
To make it easy for people to figure out an admin.
