### PR TITLE
Fix hashmap deserialization.

### DIFF
--- a/generator/app/models/RubyClientGenerator.scala
+++ b/generator/app/models/RubyClientGenerator.scala
@@ -521,7 +521,7 @@ case class RubyClientGenerator(service: ServiceDescription) {
       }
 
       case TypeInstance(Container.Map, Type(TypeKind.Primitive, name)) => {
-        withDefaultMap(fieldName, s"opts.delete(:$fieldName)", required) + ".inject({}) { |h, d| h[d0] = " + parseArgumentPrimitive(fieldName, "d[1]", name, required, default) + "; h }"
+        withDefaultMap(fieldName, s"opts.delete(:$fieldName)", required) + ".inject({}) { |h, d| h[d[0]] = " + parseArgumentPrimitive(fieldName, "d[1]", name, required, default) + "; h }"
       }
 
       case TypeInstance(Container.Singleton, Type(TypeKind.Model, name)) => {


### PR DESCRIPTION
d0 is not a variable name, since d is in scope
and d[1] is used later, it makes sense that d[0]
is the correct variable here.
