### PR TITLE
Handle gracefully Swagger spec with no model types in 200 response.

### DIFF
--- a/swagger/src/test/resources/no-resources.json
+++ b/swagger/src/test/resources/no-resources.json
@@ -1,0 +1,40 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Example with no models in the responses (just type string)",
+    "description": "Example with no models in the responses (just type string)"
+  },
+  "paths": {
+    "/return-string": {
+      "get": {
+        "description": "Returns a string",
+        "responses": {
+          "200": {
+            "description": "Just a random string",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/return-array-of-strings": {
+      "get": {
+        "description": "Returns an array of strings",
+        "responses": {
+          "200": {
+            "description": "Just an array of random strings",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {}
+}

--- a/swagger/src/test/scala/me/apidoc/swagger/SwaggerServiceValidatorSpec.scala
+++ b/swagger/src/test/scala/me/apidoc/swagger/SwaggerServiceValidatorSpec.scala
@@ -950,6 +950,24 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
           assertRefsSpec(path)
       }
     }
+
+    it("should not fail when no resource model can be found") {
+      val files = Seq("no-resources.json")
+      files.foreach {
+        filename =>
+          val path = resourcesDir + filename
+          println(s"Reading file[$path]")
+          SwaggerServiceValidator(config, readFile(path)).validate match {
+            case Left(errors) => {
+              fail(s"Service validation failed for path[$path]: " + errors.mkString(", "))
+            }
+            case Right(service) => {
+              service.resources should be(Seq())
+              service.models should be (Seq())
+            }
+          }
+      }
+    }
   }
 
   def assertRefsSpec(path: String) = {


### PR DESCRIPTION
Currently Swagger import fails (with Scala pattern matching error) if at least one of the paths' 200 response has no model type (example: string or array of string response body).
Cases like this are now ignored by ApiBuilder when looking for Resources: no errors are thrown but that resource and related paths/operations are not be imported in ApiBuilder (they cannot be imported being not objects, but at least the rest of the Swagger spec will be imported).

See the example in the issue #652 . 