### PR TITLE
Use internal parser to pull out valid path parameter names

### DIFF
--- a/core/src/main/scala/core/builder/ServiceSpecValidator.scala
+++ b/core/src/main/scala/core/builder/ServiceSpecValidator.scala
@@ -1,6 +1,6 @@
 package builder
 
-import core.{TypeValidator, TypesProvider}
+import core.{TypeValidator, TypesProvider, Util}
 import io.apibuilder.spec.v0.models.{ResponseCodeInt, Header, Method, Operation, ParameterLocation, ResponseCode}
 import io.apibuilder.spec.v0.models.{ResponseCodeUndefinedType, ResponseCodeOption, Resource, Service, Union}
 import lib.{DatatypeResolver, Kind, Methods, Primitives, Text, VersionTag}
@@ -559,9 +559,8 @@ case class ServiceSpecValidator(
                 case ParameterLocation.Path => {
                   // Path parameters are required
                   if (p.required) {
-                    // Verify that path parameter is actually in the path
-                    val index = op.path.indexOf(s":${p.name}/")
-                    if (index < 0  && !op.path.endsWith(s":${p.name}")) {
+                    // Verify that path parameter is actually in the path and immediately before or after a '/'
+                    if (!Util.namedParametersInPath(op.path).contains(p.name)) {
                       Some(opLabel(resource, op, s"path parameter[${p.name}] is missing from the path[${op.path}]"))
                     } else if (isValidInUrl(kind)) {
                       None

--- a/core/src/test/scala/core/ServicePathParametersSpec.scala
+++ b/core/src/test/scala/core/ServicePathParametersSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec}
 import org.scalatest.Matchers
 
 class ServicePathParametersSpec extends FunSpec with Matchers {
-/*
+
   describe("with a service") {
     val baseJson = """
     {
@@ -85,12 +85,16 @@ class ServicePathParametersSpec extends FunSpec with Matchers {
 
     it("other models cannot be path parameters") {
       val json = baseJson.format("GET", "/:tag")
-      TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be("Resource[user] GET /users/:tag path parameter[tag] has an invalid type[tag]. Valid types for path parameters are: boolean, decimal, integer, double, long, string, date-iso8601, date-time-iso8601, uuid")
+      TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be(
+        "Resource[user] GET /users/:tag path parameter[tag] has an invalid type[tag]. Valid types for path parameters are: enum, boolean, decimal, integer, double, long, string, date-iso8601, date-time-iso8601, uuid."
+      )
     }
 
     it("unsupported types declared as parameters are validated") {
       val json = baseJson.format("POST", "/:tags")
-      TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be("Resource[user] POST /users/:tags path parameter[tags] has an invalid type[map]. Valid types for path parameters are: boolean, decimal, integer, double, long, string, date-iso8601, date-time-iso8601, uuid")
+      TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be(
+        "Resource[user] POST /users/:tags path parameter[tags] has an invalid type[map[string]]. Valid types for path parameters are: enum, boolean, decimal, integer, double, long, string, date-iso8601, date-time-iso8601, uuid."
+      )
     }
 
   }
@@ -159,7 +163,7 @@ class ServicePathParametersSpec extends FunSpec with Matchers {
     }
 
   }
-*/
+
   it("passes correctly specified path parameters") {
     val baseJson = """
     {

--- a/core/src/test/scala/core/ServicePathParametersSpec.scala
+++ b/core/src/test/scala/core/ServicePathParametersSpec.scala
@@ -55,37 +55,37 @@ class ServicePathParametersSpec extends FunSpec with Matchers {
 
     it("numbers can be path parameters") {
       val json = baseJson.format("GET", "/:id")
-      TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be("")
+      TestHelper.serviceValidatorFromApiJson(json).errors should be(Nil)
     }
 
     it("strings can be path parameters") {
       val json = baseJson.format("GET", "/:name")
-      TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be("")
+      TestHelper.serviceValidatorFromApiJson(json).errors should be(Nil)
     }
 
     it("supports file extensions") {
       val json = baseJson.format("GET", "/:id.html")
-      TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be("")
+      TestHelper.serviceValidatorFromApiJson(json).errors should be(Nil)
     }
 
     it("parameters not defined on the model are accepted (assumed strings)") {
       val json = baseJson.format("GET", "/:some_string")
-      TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be("")
+      TestHelper.serviceValidatorFromApiJson(json).errors should be(Nil)
     }
 
     it("enums can be path parameters - assumed type is string") {
       val json = baseJson.format("GET", "/:age_group")
-      TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be("")
+      TestHelper.serviceValidatorFromApiJson(json).errors should be(Nil)
     }
 
     it("dates can be path parameters") {
       val json = baseJson.format("GET", "/:created_at_date")
-      TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be("")
+      TestHelper.serviceValidatorFromApiJson(json).errors should be(Nil)
     }
 
     it("date-time can be path parameters") {
       val json = baseJson.format("GET", "/:created_at_date_time")
-      TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be("")
+      TestHelper.serviceValidatorFromApiJson(json).errors should be(Nil)
     }
 
     it("other models cannot be path parameters") {
@@ -148,7 +148,7 @@ class ServicePathParametersSpec extends FunSpec with Matchers {
     it("can identify common type for path parameter if all union types have the same type") {
       val json = baseJson.format("guid")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("")
+      validator.errors should be(Nil)
       val userResource = validator.service.resources.head
       val op = userResource.operations.head
       val param = op.parameters.head
@@ -159,7 +159,7 @@ class ServicePathParametersSpec extends FunSpec with Matchers {
     it("uses default 'string' if path parameter type varies across union type") {
       val json = baseJson.format("age")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("")
+      validator.errors should be(Nil)
       val userResource = validator.service.resources.head
       val op = userResource.operations.head
       val param = op.parameters.head

--- a/core/src/test/scala/core/ServicePathParametersSpec.scala
+++ b/core/src/test/scala/core/ServicePathParametersSpec.scala
@@ -63,6 +63,11 @@ class ServicePathParametersSpec extends FunSpec with Matchers {
       TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be("")
     }
 
+    it("supports file extensions") {
+      val json = baseJson.format("GET", "/:id.html")
+      TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be("")
+    }
+
     it("parameters not defined on the model are accepted (assumed strings)") {
       val json = baseJson.format("GET", "/:some_string")
       TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be("")


### PR DESCRIPTION
- Add test case for paths like /users/:id.html which we supported in past
       and I think we want to continue