### PR TITLE
Introduce inline types

### DIFF
--- a/core/src/main/scala/core/builder/api_json/InternalDatatype.scala
+++ b/core/src/main/scala/core/builder/api_json/InternalDatatype.scala
@@ -1,0 +1,197 @@
+package builder.api_json
+
+import builder.JsonUtil
+import lib.Primitives
+import play.api.libs.json._
+
+
+sealed trait InternalDatatype {
+
+  def name: String
+  def required: Boolean
+  def label: String
+
+  protected def makeLabel(prefix: String = "", postfix: String = ""): String = {
+    prefix + name + postfix
+  }
+
+}
+
+object InternalDatatype {
+  case class List(name: String, required: Boolean) extends InternalDatatype {
+    override def label: String = makeLabel("[", "]")
+  }
+
+  case class Map(name: String, required: Boolean) extends InternalDatatype {
+    override def label: String = makeLabel("map[", "]")
+  }
+
+  case class Singleton(name: String, required: Boolean) extends InternalDatatype {
+    override def label: String = makeLabel()
+  }
+
+
+  val Unit: InternalDatatype = InternalDatatype.Singleton(
+    name = Primitives.Unit.toString,
+    required = true
+  )
+}
+
+private[api_json] case class InternalDatatypeBuilder() {
+
+  private[this] val dynamicEnums = scala.collection.mutable.ListBuffer[InternalEnumForm]()
+  private[this] val dynamicModels = scala.collection.mutable.ListBuffer[InternalModelForm]()
+  private[this] val dynamicUnions = scala.collection.mutable.ListBuffer[InternalUnionForm]()
+
+  private[this] val EnumMarker = "enum"
+  private[this] val ModelMarker = "model"
+  private[this] val UnionMarker = "union"
+
+  def enumForms: List[InternalEnumForm] = dynamicEnums.toList
+  def modelForms: List[InternalModelForm] = dynamicModels.toList
+  def unionForms: List[InternalUnionForm] = dynamicUnions.toList
+
+  private val ListRx = "^\\[(.*)\\]$".r
+  private val MapRx = "^map\\[(.*)\\]$".r
+  private val DefaultMapRx = "^map$".r
+
+  private[this] def apply(r: JsLookupResult): Either[Seq[String], InternalDatatype] = {
+    JsonUtil.asOptJsValue(r) match {
+      case None => Left(Seq("must be an object"))
+      case Some(v) => apply(v)
+    }
+  }
+
+  private[this] def apply(value: JsValue): Either[Seq[String], InternalDatatype] = {
+    value.asOpt[String] match {
+      case Some(v) => fromString(v)
+      case None => value.asOpt[JsObject] match {
+        case Some(v) => inlineType(v)
+        case None => Left(Seq("must be a string or an object"))
+      }
+    }
+  }
+
+  private[this] def inlineType(value: JsObject): Either[Seq[String], InternalDatatype] = {
+    JsonUtil.asOptString(value \ EnumMarker) match {
+      case None => {
+        JsonUtil.asOptString(value \ ModelMarker) match {
+          case None => {
+            JsonUtil.asOptString(value \ UnionMarker) match {
+              case None => Left(Seq(s"must specify field '$EnumMarker', '$ModelMarker' or '$UnionMarker'"))
+              case Some(unionName) => {
+                fromString(unionName) match {
+                  case Left(errors) => {
+                    Left(errors)
+                  }
+
+                  case Right(dt) => {
+                    dynamicUnions.append(
+                      InternalUnionForm(this, dt.name, value - UnionMarker)
+                    )
+                    Right(dt)
+                  }
+                }
+
+              }
+            }
+          }
+
+          case Some(modelName) => {
+            fromString(modelName) match {
+              case Left(errors) => {
+                Left(errors)
+              }
+
+              case Right(dt) => {
+                dynamicModels.append(
+                  InternalModelForm(this, dt.name, value - ModelMarker)
+                )
+                Right(dt)
+              }
+            }
+          }
+        }
+      }
+
+      case Some(enumName) => {
+        fromString(enumName) match {
+          case Left(errors) => {
+            Left(errors)
+          }
+
+          case Right(dt) => {
+            dynamicEnums.append(
+              InternalEnumForm(dt.name, value - EnumMarker)
+            )
+            Right(dt)
+          }
+        }
+      }
+    }
+  }
+
+  def fromString(value: String): Either[Seq[String], InternalDatatype] = {
+    Option(value.trim).filter(_.nonEmpty) match {
+      case None => Left(Seq("type must be a non empty string"))
+      case Some(v) => {
+        Right(
+          v match {
+            case ListRx(name) => InternalDatatype.List(formatName(name), required = true)
+            case MapRx(name) => InternalDatatype.Map(formatName(name), required = true)
+            case DefaultMapRx() => InternalDatatype.Map(Primitives.String.toString, required = true)
+            case _ => InternalDatatype.Singleton(formatName(value), required = true)
+          }
+        )
+      }
+    }
+  }
+
+  /**
+    * Make primitive datatype names case insensitive to user
+    * input. e.g. accept both 'UUID' and 'uuid' as the uuid type.
+    */
+  private def formatName(name: String): String = {
+    Primitives(name) match {
+      case None => name
+      case Some(p) => p.toString
+    }
+  }
+
+  def parseTypeFromObject(json: JsObject): Either[Seq[String], InternalDatatype] = {
+    apply(json \ "type") match {
+      case Left(errors) => {
+        Left(errors)
+      }
+
+      case Right(dt) => {
+        Right(
+          JsonUtil.asOptBoolean(json \ "required") match {
+            case None => {
+              dt
+            }
+
+            case Some(true) => {
+              // User explicitly marked this required
+              dt match {
+                case InternalDatatype.List(name, _) => InternalDatatype.List(formatName(name), required = true)
+                case InternalDatatype.Map(name, _) => InternalDatatype.Map(formatName(name), required = true)
+                case InternalDatatype.Singleton(name, _) => InternalDatatype.Singleton(formatName(name), required = true)
+              }
+            }
+
+            case Some(false) => {
+              // User explicitly marked this optional
+              dt match {
+                case InternalDatatype.List(name, _) => InternalDatatype.List(formatName(name), required = false)
+                case InternalDatatype.Map(name, _) => InternalDatatype.Map(formatName(name), required = false)
+                case InternalDatatype.Singleton(name, _) => InternalDatatype.Singleton(formatName(name), required = false)
+              }
+            }
+          }
+        )
+      }
+    }
+  }
+
+}

--- a/core/src/main/scala/core/builder/api_json/Types.scala
+++ b/core/src/main/scala/core/builder/api_json/Types.scala
@@ -19,7 +19,10 @@ private[api_json] case class InternalServiceFormTypesProvider(internal: Internal
       namespace = internal.namespace.getOrElse(""),
       name = u.name,
       plural = u.plural,
-      types = u.types.flatMap(_.datatype).map(_.name).map { core.TypesProviderUnionType }
+      types = u.types.
+        filter(_.datatype.isRight).
+        map(_.datatype.right.get.name).
+        map { core.TypesProviderUnionType }
     )
   }
 
@@ -28,11 +31,14 @@ private[api_json] case class InternalServiceFormTypesProvider(internal: Internal
       namespace = internal.namespace.getOrElse(""),
       name = m.name,
       plural = m.plural,
-      fields = m.fields.filter(_.name.isDefined).filter(_.datatype.isDefined) map { f =>
-        TypesProviderField(
-          name = f.name.get,
-          `type` = f.datatype.get.label
-        )
+      fields = m.fields.
+        filter(_.name.isDefined).
+        filter(_.datatype.isRight).
+        map { f =>
+          TypesProviderField(
+            name = f.name.get,
+            `type` = f.datatype.right.get.label
+          )
       }
     )
   }

--- a/core/src/test/scala/core/ApiJsonStructureSpec.scala
+++ b/core/src/test/scala/core/ApiJsonStructureSpec.scala
@@ -13,7 +13,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("Missing name")
+    validator.errors().mkString should be("Missing name")
   }
 
   it("name must be a string") {
@@ -25,7 +25,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("name must be a string")
+    validator.errors().mkString should be("name must be a string")
   }
 
   it("base_url must be a string") {
@@ -38,7 +38,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("base_url, if present, must be a string")
+    validator.errors().mkString should be("base_url, if present, must be a string")
   }
 
   it("description must be a string") {
@@ -51,7 +51,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("description, if present, must be a string")
+    validator.errors().mkString should be("description, if present, must be a string")
   }
 
   it("imports, headers must be arrays") {
@@ -65,7 +65,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
 
     Seq("imports", "headers").foreach { field =>
       val validator = TestHelper.serviceValidatorFromApiJson(json.format(field))
-      validator.errors.mkString("") should be(s"$field, if present, must be an array")
+      validator.errors().mkString("") should be(s"$field, if present, must be an array")
     }
   }
 
@@ -80,7 +80,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
 
     Seq("enums", "models", "unions", "resources").foreach { field =>
       val validator = TestHelper.serviceValidatorFromApiJson(json.format(field))
-      validator.errors.mkString should be(s"$field, if present, must be an object")
+      validator.errors().mkString should be(s"$field, if present, must be an object")
     }
   }
 
@@ -94,7 +94,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("Unrecognized element[resource]")
+    validator.errors().mkString should be("Unrecognized element[resource]")
   }
 
   it("validates multiple unknown keys") {
@@ -108,7 +108,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("Unrecognized elements[foo, resource]")
+    validator.errors().mkString should be("Unrecognized elements[foo, resource]")
   }
 
   it("validates models") {
@@ -125,7 +125,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString(" ") should be("Model[user] description, if present, must be a string Model[user] Missing fields")
+    validator.errors().mkString(" ") should be("Model[user] description, if present, must be a string Model[user] Missing fields")
   }
 
   it("validates model fields are objects") {
@@ -142,7 +142,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString(" ") should be("Model[user] elements of fields must be objects")
+    validator.errors().mkString(" ") should be("Model[user] elements of fields must be objects")
   }
 
   it("validates enums") {
@@ -159,7 +159,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString(" ") should be("Enum[user] description, if present, must be a string Enum[user] Missing values")
+    validator.errors().mkString(" ") should be("Enum[user] description, if present, must be a string Enum[user] Missing values")
   }
 
   it("validates enum values are objects") {
@@ -176,7 +176,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString(" ") should be("Enum[user] elements of values must be objects")
+    validator.errors().mkString(" ") should be("Enum[user] elements of values must be objects")
   }
 
   it("validates unions") {
@@ -193,7 +193,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString(" ") should be("Union[user] description, if present, must be a string Union[user] Missing types")
+    validator.errors().mkString(" ") should be("Union[user] description, if present, must be a string Union[user] Missing types")
   }
 
   it("validates union types are objects") {
@@ -210,7 +210,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString(" ") should be("Union[user] elements of types must be objects")
+    validator.errors().mkString(" ") should be("Union[user] elements of types must be objects")
   }
 
   it("validates responses") {
@@ -241,7 +241,7 @@ class ApiJsonStructureSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString(" ") should be("Resource[user] GET /users Unrecognized element[response]")
+    validator.errors().mkString(" ") should be("Resource[user] GET /users Unrecognized element[response]")
   }
 
 }

--- a/core/src/test/scala/core/ApidocVersionSpec.scala
+++ b/core/src/test/scala/core/ApidocVersionSpec.scala
@@ -13,8 +13,8 @@ class ApidocVersionSpec extends FunSpec with Matchers {
 
     it("defaults to latest version") {
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("")
-      validator.service.apidoc.version should be(io.apibuilder.spec.v0.Constants.Version)
+      validator.errors().mkString("") should be("")
+      validator.service().apidoc.version should be(io.apibuilder.spec.v0.Constants.Version)
     }
 
   }
@@ -33,13 +33,13 @@ class ApidocVersionSpec extends FunSpec with Matchers {
     it("current version is ok") {
       val json = baseJson.format(io.apibuilder.spec.v0.Constants.Version)
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("")
+      validator.errors().mkString("") should be("")
     }
 
     it("rejects invalid version") {
       val json = baseJson.format("!")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be(s"Invalid apidoc version[!]. Latest version of apidoc specification is ${io.apibuilder.spec.v0.Constants.Version}")
+      validator.errors().mkString("") should be(s"Invalid apidoc version[!]. Latest version of apidoc specification is ${io.apibuilder.spec.v0.Constants.Version}")
     }
 
   }

--- a/core/src/test/scala/core/BodyParameterSpec.scala
+++ b/core/src/test/scala/core/BodyParameterSpec.scala
@@ -48,74 +48,74 @@ class BodyParameterSpec extends FunSpec with Matchers {
 
   it("validates that body refers to a known model") {
     val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("POST", """{ "type": "foo" }""", "boolean"))
-    validator.errors.mkString("") should be(s"Resource[message] POST /messages/:mimeType body: Type[foo] not found")
+    validator.errors().mkString("") should be(s"Resource[message] POST /messages/:mimeType body: Type[foo] not found")
   }
 
   it("support primitive types in body") {
     val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("POST", """{ "type": "string", "description": "test" }""", "boolean"))
-    validator.errors.mkString("") should be("")
-    val model = validator.service.models.find(_.name == "message").get
-    val op = validator.service.resources.head.operations.head
+    validator.errors().mkString("") should be("")
+    validator.service().models.find(_.name == "message").get
+    val op = validator.service().resources.head.operations.head
     op.body.map(_.`type`) should be(Some("string"))
     op.body.flatMap(_.description) should be(Some("test"))
   }
 
   it("support arrays of primitive types in body") {
     val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("POST", """{ "type": "[string]" }""", "boolean"))
-    validator.errors.mkString("") should be("")
-    val model = validator.service.models.find(_.name == "message").get
-    val op = validator.service.resources.head.operations.head
+    validator.errors().mkString("") should be("")
+    validator.service().models.find(_.name == "message").get
+    val op = validator.service().resources.head.operations.head
     op.body.map(_.`type`) should be(Some("[string]"))
   }
 
   it("support enums in body") {
     val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("POST", """{ "type": "age_group" }""", "boolean"))
-    validator.errors.mkString("") should be("")
-    val model = validator.service.models.find(_.name == "message").get
-    val op = validator.service.resources.head.operations.head
+    validator.errors().mkString("") should be("")
+    validator.service().models.find(_.name == "message").get
+    val op = validator.service().resources.head.operations.head
     op.body.map(_.`type`) should be(Some("age_group"))
   }
 
   it("support arrays of enums in body") {
     val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("POST", """{ "type": "[age_group]" }""", "boolean"))
-    validator.errors.mkString("") should be("")
-    val model = validator.service.models.find(_.name == "message").get
-    val op = validator.service.resources.head.operations.head
+    validator.errors().mkString("") should be("")
+    validator.service().models.find(_.name == "message").get
+    val op = validator.service().resources.head.operations.head
     op.body.map(_.`type`) should be(Some("[age_group]"))
   }
 
   it("supports arrays of models in body") {
     val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("POST", """{ "type": "[message]" }""", "boolean"))
-    validator.errors.mkString("") should be("")
-    val model = validator.service.models.find(_.name == "message").get
-    val op = validator.service.resources.head.operations.head
+    validator.errors().mkString("") should be("")
+    validator.service().models.find(_.name == "message").get
+    val op = validator.service().resources.head.operations.head
     op.body.map(_.`type`) should be(Some("[message]"))
   }
 
   it("validates if body is not a map") {
     val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("POST", """"string"""", "boolean"))
-    validator.errors.mkString("") should be("Resource[message] POST /messages/:mimeType body, if present, must be an object")
+    validator.errors().mkString("") should be("Resource[message] POST /messages/:mimeType body, if present, must be an object")
   }
 
   it("validates that body cannot be specified for GET, DELETE operations") {
     Methods.MethodsNotAcceptingBodies.foreach { method =>
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format(method, """{ "type": "message" }""", "boolean"))
-      validator.errors.mkString("") should be(s"Resource[message] $method /messages/:mimeType Cannot specify body for HTTP method[$method]")
+      validator.errors().mkString("") should be(s"Resource[message] $method /messages/:mimeType Cannot specify body for HTTP method[$method]")
     }
   }
 
   it("supports models in body") {
     val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("POST", """{ "type": "message" }""", "boolean"))
-    validator.errors.mkString("") should be("")
-    val model = validator.service.models.find(_.name == "message").get
-    val op = validator.service.resources.head.operations.head
+    validator.errors().mkString("") should be("")
+    validator.service().models.find(_.name == "message").get
+    val op = validator.service().resources.head.operations.head
     op.body.map(_.`type`) should be(Some("message"))
   }
 
   it("If body specified, all parameters are either PATH or QUERY") {
     val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("POST", """{ "type": "message" }""", "boolean"))
-    validator.errors.mkString("") should be("")
-    val op = validator.service.resources.head.operations.head
+    validator.errors().mkString("") should be("")
+    val op = validator.service().resources.head.operations.head
     val params = op.parameters
     params.size should be(2)
     params.find(_.name == "mimeType").get.location should be(ParameterLocation.Path)
@@ -124,27 +124,27 @@ class BodyParameterSpec extends FunSpec with Matchers {
 
   it("body can be an array") {
     val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("POST", """{ "type": "[message]" }""", "boolean"))
-    validator.errors.mkString("") should be("")
-    val op = validator.service.resources.head.operations.head
+    validator.errors().mkString("") should be("")
+    val op = validator.service().resources.head.operations.head
     op.body.map(_.`type`) should be(Some("[message]"))
   }
 
   it("validates missing datatype") {
     val baseJsonWithInvalidModel = baseJson.format("POST", """{ "type": "" }""", "age_group")
     val validator = TestHelper.serviceValidatorFromApiJson(baseJsonWithInvalidModel)
-    validator.errors.mkString("") should be(s"Resource[message] POST /messages/:mimeType Body missing type")
+    validator.errors().mkString("") should be(s"Resource[message] POST /messages/:mimeType Body type must be a non empty string")
   }
 
   it("If body specified, parameters can be enums") {
     val baseJsonWithInvalidModel = baseJson.format("POST", """{ "type": "message" }""", "age_group")
     val validator = TestHelper.serviceValidatorFromApiJson(baseJsonWithInvalidModel)
-    validator.errors.mkString("") should be("")
+    validator.errors().mkString("") should be("")
   }
 
   it("If body specified, parameters cannot be models") {
     val baseJsonWithInvalidModel = baseJson.format("POST", """{ "type": "message" }""", "message")
     val validator = TestHelper.serviceValidatorFromApiJson(baseJsonWithInvalidModel)
-    validator.errors.mkString("") should be(s"Resource[message] POST /messages/:mimeType Parameter[debug] has an invalid type[message]. Model and union types are not supported as query parameters.")
+    validator.errors().mkString("") should be(s"Resource[message] POST /messages/:mimeType Parameter[debug] has an invalid type[message]. Model and union types are not supported as query parameters.")
   }
 
 }

--- a/core/src/test/scala/core/BrokenSpec.scala
+++ b/core/src/test/scala/core/BrokenSpec.scala
@@ -21,8 +21,8 @@ class BrokenSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("")
-    val fields = validator.service.models.head.fields
+    validator.errors().mkString should be("")
+    val fields = validator.service().models.head.fields
     fields.find { _.name == "guid" }.get.`type` should be("uuid")
     fields.find { _.name == "tags" }.get.`type` should be("[string]")
   }
@@ -59,9 +59,9 @@ class BrokenSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("")
+    validator.errors().mkString should be("")
 
-    val operation = validator.service.resources.head.operations.head
+    val operation = validator.service().resources.head.operations.head
     operation.method should be(Method.Post)
     operation.parameters.find { _.name == "guid" }.get.`type` should be("uuid")
 

--- a/core/src/test/scala/core/DeprecationSpec.scala
+++ b/core/src/test/scala/core/DeprecationSpec.scala
@@ -33,9 +33,9 @@ class DeprecationSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    validator.service.enums.find(_.name == "old_content_type").get.deprecation.flatMap(_.description) should be(Some("blah"))
-    validator.service.enums.find(_.name == "content_type").get.deprecation.flatMap(_.description) should be(None)
+    validator.errors().mkString("") should be("")
+    validator.service().enums.find(_.name == "old_content_type").get.deprecation.flatMap(_.description) should be(Some("blah"))
+    validator.service().enums.find(_.name == "content_type").get.deprecation.flatMap(_.description) should be(None)
   }
 
   it("enum value") {
@@ -56,8 +56,8 @@ class DeprecationSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    val ct = validator.service.enums.find(_.name == "content_type").get
+    validator.errors().mkString("") should be("")
+    val ct = validator.service().enums.find(_.name == "content_type").get
 
     ct.values.find(_.name == "application/json").get.deprecation.flatMap(_.description) should be(Some("blah"))
     ct.values.find(_.name == "application/xml").get.deprecation.flatMap(_.description) should be(None)
@@ -105,9 +105,9 @@ class DeprecationSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    validator.service.unions.find(_.name == "old_content_type").get.deprecation.flatMap(_.description) should be(Some("blah"))
-    validator.service.unions.find(_.name == "content_type").get.deprecation.flatMap(_.description) should be(None)
+    validator.errors().mkString("") should be("")
+    validator.service().unions.find(_.name == "old_content_type").get.deprecation.flatMap(_.description) should be(Some("blah"))
+    validator.service().unions.find(_.name == "content_type").get.deprecation.flatMap(_.description) should be(None)
   }
 
   it("union type") {
@@ -144,8 +144,8 @@ class DeprecationSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    val union = validator.service.unions.find(_.name == "content_type").get
+    validator.errors().mkString("") should be("")
+    val union = validator.service().unions.find(_.name == "content_type").get
     union.types.find(_.`type` == "api_json").get.deprecation.flatMap(_.description) should be(Some("blah"))
     union.types.find(_.`type` == "avro_idl").get.deprecation.flatMap(_.description) should be(None)
   }
@@ -176,9 +176,9 @@ class DeprecationSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    validator.service.models.find(_.name == "api_json").get.deprecation.flatMap(_.description) should be(Some("blah"))
-    validator.service.models.find(_.name == "avro_idl").get.deprecation.flatMap(_.description) should be(None)
+    validator.errors().mkString("") should be("")
+    validator.service().models.find(_.name == "api_json").get.deprecation.flatMap(_.description) should be(Some("blah"))
+    validator.service().models.find(_.name == "avro_idl").get.deprecation.flatMap(_.description) should be(None)
   }
 
   it("field") {
@@ -201,8 +201,8 @@ class DeprecationSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    val user = validator.service.models.find(_.name == "user").get
+    validator.errors().mkString("") should be("")
+    val user = validator.service().models.find(_.name == "user").get
     user.fields.find(_.name == "id").get.deprecation.flatMap(_.description) should be(None)
     user.fields.find(_.name == "email").get.deprecation.flatMap(_.description) should be(Some("blah"))
   }
@@ -236,9 +236,9 @@ class DeprecationSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    validator.service.resources.find(_.`type` == "user").get.deprecation.flatMap(_.description) should be(None)
-    validator.service.resources.find(_.`type` == "old_user").get.deprecation.flatMap(_.description) should be(Some("blah"))
+    validator.errors().mkString("") should be("")
+    validator.service().resources.find(_.`type` == "user").get.deprecation.flatMap(_.description) should be(None)
+    validator.service().resources.find(_.`type` == "old_user").get.deprecation.flatMap(_.description) should be(Some("blah"))
   }
 
   it("operation") {
@@ -263,8 +263,8 @@ class DeprecationSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    val resource = validator.service.resources.find(_.`type` == "user").get
+    validator.errors().mkString("") should be("")
+    val resource = validator.service().resources.find(_.`type` == "user").get
     resource.operations.find(_.method == Method.Get).get.deprecation.flatMap(_.description) should be(None)
     resource.operations.find(_.method == Method.Delete).get.deprecation.flatMap(_.description) should be(Some("blah"))
   }
@@ -296,9 +296,9 @@ class DeprecationSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
+    validator.errors().mkString("") should be("")
 
-    val resource = validator.service.resources.find(_.`type` == "user").get
+    val resource = validator.service().resources.find(_.`type` == "user").get
     val op = resource.operations.head
     op.parameters.find(_.name == "id").get.deprecation.flatMap(_.description) should be(None)
     op.parameters.find(_.name == "guid").get.deprecation.flatMap(_.description) should be(Some("blah"))
@@ -331,9 +331,9 @@ class DeprecationSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
+    validator.errors().mkString("") should be("")
 
-    val resource = validator.service.resources.find(_.`type` == "user").get
+    val resource = validator.service().resources.find(_.`type` == "user").get
     val op = resource.operations.head
     op.responses.find(r => TestHelper.responseCode(r.code) == "200").get.deprecation.flatMap(_.description) should be(None)
     op.responses.find(r => TestHelper.responseCode(r.code) == "201").get.deprecation.flatMap(_.description) should be(Some("blah"))
@@ -367,9 +367,9 @@ class DeprecationSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
+    validator.errors().mkString("") should be("")
 
-    val resource = validator.service.resources.find(_.`type` == "user").get
+    val resource = validator.service().resources.find(_.`type` == "user").get
     resource.operations.find(_.method == Method.Post).get.body.get.deprecation.flatMap(_.description) should be(None)
     resource.operations.find(_.method == Method.Put).get.body.get.deprecation.flatMap(_.description) should be(Some("blah"))
   }
@@ -388,10 +388,10 @@ class DeprecationSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
+    validator.errors().mkString("") should be("")
 
-    validator.service.headers.find(_.`name` == "Content-Type").get.deprecation.flatMap(_.description) should be(None)
-    validator.service.headers.find(_.`name` == "Old-Content-Type").get.deprecation.flatMap(_.description) should be(Some("blah"))
+    validator.service().headers.find(_.`name` == "Content-Type").get.deprecation.flatMap(_.description) should be(None)
+    validator.service().headers.find(_.`name` == "Old-Content-Type").get.deprecation.flatMap(_.description) should be(Some("blah"))
   }
 
 
@@ -408,8 +408,8 @@ class DeprecationSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    validator.service.headers.find(_.`name` == "Content-Type").get.deprecation.get.description should be(None)
+    validator.errors().mkString("") should be("")
+    validator.service().headers.find(_.`name` == "Content-Type").get.deprecation.get.description should be(None)
   }
 
 }

--- a/core/src/test/scala/core/ImportServiceSpec.scala
+++ b/core/src/test/scala/core/ImportServiceSpec.scala
@@ -27,22 +27,22 @@ class ImportServiceSpec extends FunSpec with Matchers {
         "imports": [ { "foo": "bar" } ]
       }"""
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString(",") should be("Import Unrecognized element[foo],Import Missing uri")
+      validator.errors().mkString(",") should be("Import Unrecognized element[foo],Import Missing uri")
     }
 
     it("import uri cannot be empty") {
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("  "))
-      validator.errors.mkString("") should be("Import uri must be a non empty string")
+      validator.errors().mkString("") should be("Import uri must be a non empty string")
     }
 
     it("import uri starts with a valid protocol") {
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("foobar"))
-      validator.errors.mkString("") should be("URI[foobar] must start with http://, https://, or file://")
+      validator.errors().mkString("") should be("URI[foobar] must start with http://, https://, or file://")
     }
 
     it("import uri does not end with a /") {
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("http://www.apidoc.me/"))
-      validator.errors.mkString("") should be("URI[http://www.apidoc.me/] cannot end with a '/'")
+      validator.errors().mkString("") should be("URI[http://www.apidoc.me/] cannot end with a '/'")
     }
 
   }

--- a/core/src/test/scala/core/ImportedResourcePathsSpec.scala
+++ b/core/src/test/scala/core/ImportedResourcePathsSpec.scala
@@ -41,7 +41,7 @@ class ImportedResourcePathsSpec extends FunSpec with Matchers {
     val validator = TestHelper.serviceValidatorFromApiJson(user, fetcher = fetcher)
     validator.errors should be(Nil)
 
-    val userResource = validator.service.resources.head
+    val userResource = validator.service().resources.head
     userResource.operations.map(_.path) should be(Seq("/users"))
   }
 

--- a/core/src/test/scala/core/InfoSpec.scala
+++ b/core/src/test/scala/core/InfoSpec.scala
@@ -23,8 +23,8 @@ class InfoSpec extends FunSpec with Matchers {
     it("accepts empty objects") {
       val json = baseJson.format("")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("")
-      validator.service.info should be(Info(license = None, contact = None))
+      validator.errors().mkString("") should be("")
+      validator.service().info should be(Info(license = None, contact = None))
     }
 
     it("contact") {
@@ -36,13 +36,13 @@ class InfoSpec extends FunSpec with Matchers {
         }
       """)
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("")
+      validator.errors().mkString("") should be("")
       val contact = Contact(
         name = Some("Foo"),
         email = Some("Foo@test.apibuilder.me"),
         url = Some("http://www.apidoc.me")
       )
-      validator.service.info should be(Info(contact = Some(contact)))
+      validator.service().info should be(Info(contact = Some(contact)))
     }
 
     it("license") {
@@ -53,12 +53,12 @@ class InfoSpec extends FunSpec with Matchers {
         }
       """)
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("")
+      validator.errors().mkString("") should be("")
       val license = License(
         name = "MIT",
         url = Some("http://opensource.org/licenses/MIT")
       )
-      validator.service.info should be(Info(license = Some(license)))
+      validator.service().info should be(Info(license = Some(license)))
     }
 
     it("validates license requires name") {
@@ -68,7 +68,7 @@ class InfoSpec extends FunSpec with Matchers {
         }
       """)
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("License must have a name")
+      validator.errors().mkString("") should be("License must have a name")
     }
 
   }

--- a/core/src/test/scala/core/InlineEnumInModelFieldsSpec.scala
+++ b/core/src/test/scala/core/InlineEnumInModelFieldsSpec.scala
@@ -1,0 +1,64 @@
+package core
+
+import org.scalatest.{FunSpec, Matchers}
+
+class InlineEnumInModelFieldsSpec extends FunSpec with Matchers {
+
+  def buildJson(
+    required: Boolean
+  ): String = {
+    s"""
+    {
+      "name": "Api Doc",
+
+      "models": {
+        "user": {
+          "fields": [
+            {
+             "name": "type",
+             "required": $required,
+              "type": {
+                "enum": "user_type",
+                "values": [
+                  { "name": "guest" },
+                  { "name": "registered" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+    """
+  }
+
+  it("supports an inline model field") {
+    val service = TestHelper.serviceValidatorFromApiJson(buildJson(required = true)).service()
+    val enum = service.enums.headOption.getOrElse {
+      sys.error("No enum created")
+    }
+    enum.name should equal("user_type")
+    enum.values.map(_.name) should equal(
+      Seq("guest", "registered")
+    )
+
+    val field = service.models.headOption.getOrElse {
+      sys.error("No model created")
+    }.fields.headOption.getOrElse {
+      sys.error("No field created")
+    }
+
+    field.name should equal("type")
+    field.`type` should equal("user_type")
+    field.required should be(true)
+  }
+
+  it("supports optional inline model field") {
+    val service = TestHelper.serviceValidatorFromApiJson(buildJson(required = false)).service()
+    service.models.headOption.getOrElse {
+      sys.error("No model created")
+    }.fields.headOption.getOrElse {
+      sys.error("No field created")
+    }.required should be(false)
+  }
+}

--- a/core/src/test/scala/core/InlineEnumsSpec.scala
+++ b/core/src/test/scala/core/InlineEnumsSpec.scala
@@ -1,0 +1,150 @@
+package core
+
+import org.scalatest.{FunSpec, Matchers}
+
+class InlineEnumsSpec extends FunSpec with Matchers {
+
+  def buildJson(
+    typ: String =
+      """
+        |{
+        |  "type": {
+        |    "enum": "user_post_error_code",
+        |    "description": "A test enum",
+        |    "values": [
+        |      { "name": "invalid_email" }
+        |    ]
+        |  }
+        |}
+      """.stripMargin.trim,
+    extras: String = ""    
+  ): String = {
+    s"""
+    {
+      "name": "Api Doc",
+$extras
+      "models": {
+        "user": {
+          "fields": [
+            { "name": "guid", "type": "uuid" }
+          ]
+        }
+      },
+
+      "resources": {
+        "user": {
+          "operations": [
+            {
+              "method": "POST",
+              "responses": {
+                "422": $typ
+              }
+            }
+          ]
+        }
+      }
+    }
+    """
+  }
+
+  it("returns a good error message on invalid type") {
+    TestHelper.serviceValidatorFromApiJson(buildJson("[]")).errors() should equal(
+      Seq("Resource[user] POST /users 422: value must be an object")
+    )
+
+    TestHelper.serviceValidatorFromApiJson(buildJson(
+      """
+        |{ "type": {} }
+      """.stripMargin
+    )).errors() should equal(
+      Seq("Resource[user] POST /users 422 type: must specify field 'enum', 'model' or 'union'")
+    )
+
+    TestHelper.serviceValidatorFromApiJson(buildJson(
+      """
+        |{ "type": [] }
+      """.stripMargin
+    )).errors() should equal(
+      Seq("Resource[user] POST /users 422 type: must be a string or an object")
+    )
+  }
+
+  it("validates inline enum names") {
+    val json = buildJson(
+      extras =
+        """
+          |"enums": {
+          |  "user_post_error_code": {
+          |    "values": [
+          |      { "name": "invalid_email" }
+          |    ]
+          |  }
+          |},
+        """.stripMargin.trim
+    )
+
+    TestHelper.serviceValidatorFromApiJson(json).errors() should equal(
+      Seq("Enum[user_post_error_code] appears more than once")
+    )
+  }
+
+  it("supports an inline enum") {
+    val service = TestHelper.serviceValidatorFromApiJson(buildJson()).service()
+    val enum = service.enums.headOption.getOrElse {
+      sys.error("No enum created")
+    }
+    enum.name should equal("user_post_error_code")
+    enum.description should equal(Some("A test enum"))
+    enum.values.map(_.name) should equal(Seq("invalid_email"))
+
+    val response = service.resources.head.operations.head.responses.head
+    response.`type` should equal("user_post_error_code")
+  }
+
+  it("supports an inline enum defined as a list") {
+    val service = TestHelper.serviceValidatorFromApiJson(buildJson(
+      """
+        |{
+        |  "type": {
+        |    "enum": "[user_post_error_code]",
+        |    "values": [
+        |      { "name": "invalid_email" }
+        |    ]
+        |  }
+        |}
+      """.stripMargin.trim
+    )).service()
+    val enum = service.enums.headOption.getOrElse {
+      sys.error("No enum created")
+    }
+    enum.name should equal("user_post_error_code")
+    enum.values.map(_.name) should equal(Seq("invalid_email"))
+
+    val response = service.resources.head.operations.head.responses.head
+    response.`type` should equal("[user_post_error_code]")
+  }
+
+  it("supports an inline enum defined as a map") {
+    val service = TestHelper.serviceValidatorFromApiJson(buildJson(
+      """
+        |{
+        |  "type": {
+        |    "enum": "map[user_post_error_code]",
+        |    "values": [
+        |      { "name": "invalid_email" }
+        |    ]
+        |  }
+        |}
+      """.stripMargin.trim
+    )).service()
+    val enum = service.enums.headOption.getOrElse {
+      sys.error("No enum created")
+    }
+    enum.name should equal("user_post_error_code")
+    enum.values.map(_.name) should equal(Seq("invalid_email"))
+
+    val response = service.resources.head.operations.head.responses.head
+    response.`type` should equal("map[user_post_error_code]")
+  }
+
+}

--- a/core/src/test/scala/core/InlineModelsSpec.scala
+++ b/core/src/test/scala/core/InlineModelsSpec.scala
@@ -1,0 +1,132 @@
+package core
+
+import org.scalatest.{FunSpec, Matchers}
+
+class InlineModelsSpec extends FunSpec with Matchers {
+
+  def buildJson(
+    typ: String =
+    """
+      |{
+      |  "type": {
+      |    "model": "user_post_error",
+      |    "description": "A test inline model",
+      |    "fields": [
+      |      { "name": "messages", "type": "[string]" }
+      |    ]
+      |  }
+      |}
+    """.stripMargin.trim
+  ): String = {
+    s"""
+    {
+      "name": "Api Doc",
+
+      "models": {
+        "user": {
+          "fields": [
+            { "name": "guid", "type": "uuid" }
+          ]
+        }
+      },
+
+      "resources": {
+        "user": {
+          "operations": [
+            {
+              "method": "POST",
+              "responses": {
+                "422": $typ
+              }
+            }
+          ]
+        }
+      }
+    }
+    """
+  }
+
+  it("supports an inline model field") {
+    val service = TestHelper.serviceValidatorFromApiJson(buildJson()).service()
+    val model = service.models.find(_.name == "user_post_error").getOrElse {
+      sys.error("No user_post_error model created")
+    }
+    model.name should equal("user_post_error")
+    model.description should equal(Some("A test inline model"))
+    model.fields.toList match {
+      case f :: Nil => {
+        f.name should equal("messages")
+        f.`type` should equal("[string]")
+      }
+      case _ => sys.error("Expected one field")
+    }
+  }
+
+  it("supports an inline model containing a field with an inline enum") {
+    val json = """
+    {
+      "name": "Api Doc",
+
+      "models": {
+        "user": {
+          "fields": [
+            { "name": "guid", "type": "uuid" }
+          ]
+        }
+      },
+
+      "resources": {
+        "user": {
+          "operations": [
+            {
+              "method": "POST",
+              "responses": {
+                "422": {
+                  "type": {
+                    "model": "[user_post_error]",
+                    "fields": [
+                      {
+                        "name": "code",
+                        "type": {
+                          "enum": "user_post_error_code",
+                          "values": [
+                            { "name": "invalid_email_address" },
+                            { "name": "name_cannot_be_empty" }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+    """
+    val service = TestHelper.serviceValidatorFromApiJson(json).service()
+    val model = service.models.find(_.name == "user_post_error").getOrElse {
+      sys.error("No user_post_error model created")
+    }
+    model.name should equal("user_post_error")
+    model.fields.toList match {
+      case f :: Nil => {
+        f.name should equal("code")
+        f.`type` should equal("user_post_error_code")
+      }
+      case _ => sys.error("Expected one field")
+    }
+
+    val enum = service.enums.find(_.name == "user_post_error_code").getOrElse {
+      sys.error("No user_post_error_code enum created")
+    }
+    enum.values.map(_.name) should equal(
+      Seq("invalid_email_address", "name_cannot_be_empty")
+    )
+
+    val response = service.resources.head.operations.head.responses.head
+    response.`type` should equal("[user_post_error]")
+  }
+
+}

--- a/core/src/test/scala/core/InlineUnionsSpec.scala
+++ b/core/src/test/scala/core/InlineUnionsSpec.scala
@@ -1,0 +1,174 @@
+package core
+
+import org.scalatest.{FunSpec, Matchers}
+
+class InlineUnionsSpec extends FunSpec with Matchers {
+
+  it("union types support inline models") {
+    val json =
+      """
+    {
+      "name": "Api Doc",
+
+      "unions": {
+        "user": {
+          "discriminator": "discriminator",
+          "types": [
+            {
+              "type": {
+                "model": "guest_user",
+                "fields": [ { "name": "guid", "type": "uuid" }]
+              }
+            },
+            {
+              "type": {
+                "model": "registered_user",
+                "fields": [
+                  { "name": "guid", "type": "uuid" },
+                  { "name": "name", "type": "string" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+    """
+
+    val service = TestHelper.serviceValidatorFromApiJson(json).service()
+    service.models.find(_.name == "guest_user").getOrElse {
+      sys.error("No guest_user model created")
+    }.fields.map(_.name) should equal(
+      Seq("guid")
+    )
+
+    service.models.find(_.name == "registered_user").getOrElse {
+      sys.error("No registered_user model created")
+    }.fields.map(_.name) should equal(
+      Seq("guid", "name")
+    )
+
+    service.unions.find(_.name == "user").getOrElse {
+      sys.error("No user union created")
+    }.types.map(_.`type`) should equal(
+      Seq("guest_user", "registered_user")
+    )
+  }
+
+  it("supports an inline union in response") {
+    val json = """
+                 |{
+                 |  "name": "Api Doc",
+                 |
+                 |  "models": {
+                 |    "user": {
+                 |      "fields": [
+                 |        { "name": "guid", "type": "uuid" }
+                 |      ]
+                 |    }
+                 |  },
+                 |
+                 |  "resources": {
+                 |    "user": {
+                 |      "operations": [
+                 |        {
+                 |          "method": "POST",
+                 |          "responses": {
+                 |            "422": {
+                 |              "type": {
+                 |                "union": "[user_error]",
+                 |                "types": [
+                 |                  {
+                 |                    "type": {
+                 |                      "model": "simple_user_error",
+                 |                      "fields": [
+                 |                        {
+                 |                          "name": "code",
+                 |                          "type": {
+                 |                            "enum": "simple_user_error_code",
+                 |                            "values": [
+                 |                              { "name": "name_cannot_be_empty" }
+                 |                            ]
+                 |                          }
+                 |                        }
+                 |                      ]
+                 |                    }
+                 |                  },
+                 |
+                 |                  {
+                 |                    "type": {
+                 |                      "model": "parameterized_user_error",
+                 |                      "fields": [
+                 |                        {
+                 |                          "name": "code",
+                 |                          "type": {
+                 |                            "enum": "parameterized_user_error_code",
+                 |                            "values": [
+                 |                              { "name": "invalid_email_address" }
+                 |                            ]
+                 |                          }
+                 |                        },
+                 |                        {
+                 |                          "name": "suggestion",
+                 |                          "type": "string"
+                 |                        }
+                 |                      ]
+                 |                    }
+                 |                  }
+                 |                ]
+                 |              }
+                 |            }
+                 |          }
+                 |        }
+                 |      ]
+                 |    }
+                 |  }
+                 |}
+    """.stripMargin
+    val service = TestHelper.serviceValidatorFromApiJson(json).service()
+
+    service.models.find(_.name == "simple_user_error").getOrElse {
+      sys.error("No simple_user_error model created")
+    }.fields.toList match {
+      case code :: Nil => {
+        code.name should equal("code")
+        code.`type` should equal("simple_user_error_code")
+      }
+      case _ => sys.error("Expected one field")
+    }
+
+    service.enums.find(_.name == "simple_user_error_code").getOrElse {
+      sys.error("No simple_user_error_code enum created")
+    }.values.map(_.name) should equal(
+      Seq("name_cannot_be_empty")
+    )
+
+    service.models.find(_.name == "parameterized_user_error").getOrElse {
+      sys.error("No parameterized_user_error model created")
+    }.fields.toList match {
+      case code :: suggestion :: Nil => {
+        code.name should equal("code")
+        code.`type` should equal("parameterized_user_error_code")
+
+        suggestion.name should equal("suggestion")
+        suggestion.`type` should equal("string")
+      }
+      case _ => sys.error("Expected one field")
+    }
+
+    service.enums.find(_.name == "parameterized_user_error_code").getOrElse {
+      sys.error("No parameterized_user_error_code enum created")
+    }.values.map(_.name) should equal(
+      Seq("invalid_email_address")
+    )
+
+    service.unions.find(_.name == "user_error").getOrElse {
+      sys.error("no user_error union")
+    }.types.map(_.`type`) should equal(
+      Seq("simple_user_error", "parameterized_user_error")
+    )
+
+    val response = service.resources.head.operations.head.responses.head
+    response.`type` should equal("[user_error]")
+  }
+}

--- a/core/src/test/scala/core/ServiceDefaultsSpec.scala
+++ b/core/src/test/scala/core/ServiceDefaultsSpec.scala
@@ -19,9 +19,9 @@ class ServiceDefaultsSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
+    validator.errors().mkString("") should be("")
 
-    val createdAt = validator.service.models.head.fields.find { _.name == "created_at" }.get
+    val createdAt = validator.service().models.head.fields.find { _.name == "created_at" }.get
     createdAt.default should be(Some("2014-01-01"))
   }
 
@@ -41,13 +41,13 @@ class ServiceDefaultsSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
+    validator.errors().mkString("") should be("")
 
-    val isActiveField = validator.service.models.head.fields.find { _.name == "is_active" }.get
+    val isActiveField = validator.service().models.head.fields.find { _.name == "is_active" }.get
     isActiveField.default should be(Some("true"))
     isActiveField.required should be(true)
 
-    val isAthleteField = validator.service.models.head.fields.find { _.name == "is_athlete" }.get
+    val isAthleteField = validator.service().models.head.fields.find { _.name == "is_athlete" }.get
     isAthleteField.default should be(Some("false"))
     isAthleteField.required should be(true)
   }
@@ -67,7 +67,7 @@ class ServiceDefaultsSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("user.is_active Value[1] is not a valid boolean. Must be one of: true, false")
+    validator.errors().mkString("") should be("user.is_active Value[1] is not a valid boolean. Must be one of: true, false")
   }
 
   it("fields with defaults must be marked required") {
@@ -86,14 +86,14 @@ class ServiceDefaultsSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("user.created_at has a default specified. It must be marked required")
+    validator.errors().mkString("") should be("user.created_at has a default specified. It must be marked required")
   }
 
   def buildMinMaxErrors(
     default: Number,
     min: Option[Long] = None,
     max: Option[Long] = None
-  ) = {
+  ): Seq[String] = {
     val props = Seq(
       Some(s""""default": "$default""""),
       min.map { v => s""""minimum": "$v"""" },
@@ -112,8 +112,7 @@ class ServiceDefaultsSpec extends FunSpec with Matchers {
       }
     }
     """
-    TestHelper.serviceValidatorFromApiJson(json).errors
-
+    TestHelper.serviceValidatorFromApiJson(json).errors()
   }
 
   it("numeric default is in between min, max") {
@@ -126,7 +125,7 @@ class ServiceDefaultsSpec extends FunSpec with Matchers {
     buildMinMaxErrors(1, max = Some(2)) should be(Nil)
   }
   
-  it("numeric default ourside of min, max") {
+  it("numeric default ourtide of min, max") {
     buildMinMaxErrors(1, min = Some(2)) should be(
       Seq("user.age default[1] must be >= specified minimum[2]")
     )

--- a/core/src/test/scala/core/ServiceEnumSpec.scala
+++ b/core/src/test/scala/core/ServiceEnumSpec.scala
@@ -45,21 +45,21 @@ class ServiceEnumSpec extends FunSpec with Matchers {
     it("supports a known default") {
       val json = baseJson.format("", """, "default": "Twenties" """, "")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("")
-      val field = validator.service.models.head.fields.find(_.name == "age_group").get
+      validator.errors().mkString("") should be("")
+      val field = validator.service().models.head.fields.find(_.name == "age_group").get
       field.default should be(Some("Twenties"))
     }
 
     it("validates unknown defaults") {
       val json = baseJson.format("", """, "default": "other" """, "")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("user.age_group default[other] is not a valid value for enum[age_group]. Valid values are: Twenties, Thirties")
+      validator.errors().mkString("") should be("user.age_group default[other] is not a valid value for enum[age_group]. Valid values are: Twenties, Thirties")
     }
 
     it("validates unknown defaults in parameters") {
       val json = baseJson.format("", "", """, "default": "other" """)
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("Resource[user] GET /users param[age_group] default[other] is not a valid value for enum[age_group]. Valid values are: Twenties, Thirties")
+      validator.errors().mkString("") should be("Resource[user] GET /users param[age_group] default[other] is not a valid value for enum[age_group]. Valid values are: Twenties, Thirties")
     }
 
   }
@@ -67,15 +67,15 @@ class ServiceEnumSpec extends FunSpec with Matchers {
   it("field can be defined as an enum") {
     val json = baseJson.format("", "", "")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    val ageGroup = validator.service.models.head.fields.find { _.name == "age_group" }.get
+    validator.errors().mkString("") should be("")
+    val ageGroup = validator.service().models.head.fields.find { _.name == "age_group" }.get
     ageGroup.`type` should be("age_group")
   }
 
   it("validates that enum values do not start with numbers") {
     val json = baseJson.format(""", { "name": "1" } """, "", "")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("Enum[age_group] value[1] is invalid: must start with a letter")
+    validator.errors().mkString("") should be("Enum[age_group] value[1] is invalid: must start with a letter")
   }
 
 }

--- a/core/src/test/scala/core/ServiceHeadersSpec.scala
+++ b/core/src/test/scala/core/ServiceHeadersSpec.scala
@@ -30,10 +30,10 @@ class ServiceHeadersSpec extends FunSpec with Matchers {
 
     it("parses headers") {
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson)
-      validator.errors.mkString("") should be("")
-      val ctEnum = validator.service.enums.find(_.name == "content_type").get
+      validator.errors().mkString("") should be("")
+      val ctEnum = validator.service().enums.find(_.name == "content_type").get
 
-      val ct = validator.service.headers.find(_.name == "Content-Type").get
+      val ct = validator.service().headers.find(_.name == "Content-Type").get
       ct.name should be("Content-Type")
       ct.`type` should be("content_type")
       ct.default should be(None)
@@ -41,21 +41,21 @@ class ServiceHeadersSpec extends FunSpec with Matchers {
       ct.description should be(None)
       ct.required should be(true)
 
-      val foo = validator.service.headers.find(_.name == "X-Foo").get
+      val foo = validator.service().headers.find(_.name == "X-Foo").get
       foo.name should be("X-Foo")
       foo.`type` should be("string")
       foo.default should be(Some("bar"))
       foo.description should be(Some("test"))
       foo.required should be(true)
 
-      val bar = validator.service.headers.find(_.name == "X-Bar").get
+      val bar = validator.service().headers.find(_.name == "X-Bar").get
       bar.name should be("X-Bar")
       bar.`type` should be("string")
       bar.default should be(None)
       bar.description should be(None)
       bar.required should be(false)
 
-      val multi = validator.service.headers.find(_.name == "X-Multi").get
+      val multi = validator.service().headers.find(_.name == "X-Multi").get
       multi.name should be("X-Multi")
       multi.`type` should be("[string]")
       multi.default should be(None)
@@ -79,25 +79,25 @@ class ServiceHeadersSpec extends FunSpec with Matchers {
     it("requires name") {
       val json = baseJson.format("""{ "type": "string" }""")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("Header[] Missing name")
+      validator.errors().mkString("") should be("Header[] Missing name")
     }
 
     it("requires type") {
       val json = baseJson.format("""{ "name": "no_type" }""")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("Header[no_type] Missing type")
+      validator.errors().mkString("") should be("Header[no_type] Missing type")
     }
 
     it("validates type") {
       val json = baseJson.format("""{ "name": "invalid_type", "type": "integer" }""")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("Header[invalid_type] type[integer] is invalid: Must be a string or the name of an enum")
+      validator.errors().mkString("") should be("Header[invalid_type] type[integer] is invalid: Must be a string or the name of an enum")
     }
 
     it("validates duplicates") {
       val json = baseJson.format("""{ "name": "dup", "type": "string" }, { "name": "dup", "type": "string" }""")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("Header[dup] appears more than once")
+      validator.errors().mkString("") should be("Header[dup] appears more than once")
     }
 
   }

--- a/core/src/test/scala/core/ServiceInternalReferencesSpec.scala
+++ b/core/src/test/scala/core/ServiceInternalReferencesSpec.scala
@@ -25,12 +25,12 @@ class ServiceInternalReferencesSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
+    validator.errors().mkString("") should be("")
 
-    val barField = validator.service.models.find(_.name == "foo").get.fields.find(_.name == "bar").get
+    val barField = validator.service().models.find(_.name == "foo").get.fields.find(_.name == "bar").get
     barField.`type` should be("bar")
 
-    val fooField = validator.service.models.find(_.name == "bar").get.fields.find(_.name == "foo").get
+    val fooField = validator.service().models.find(_.name == "bar").get.fields.find(_.name == "foo").get
     fooField.`type` should be("foo")
   }
 
@@ -59,8 +59,8 @@ class ServiceInternalReferencesSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    val model = validator.service.models.find(_.name == "user_variant").get
+    validator.errors().mkString("") should be("")
+    val model = validator.service().models.find(_.name == "user_variant").get
     val parentField = model.fields.find(_.name == "parent").get
     parentField.`type` should be("user_variant")
   }

--- a/core/src/test/scala/core/ServiceMapSpec.scala
+++ b/core/src/test/scala/core/ServiceMapSpec.scala
@@ -21,71 +21,71 @@ class ServiceMapSpec extends FunSpec with Matchers {
   it("accepts type: map, defaulting to element type of string for backwards compatibility") {
     val json = baseJson.format("""{ "name": "tags", "type": "map" }""")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    val tags = validator.service.models.head.fields.head
+    validator.errors().mkString("") should be("")
+    val tags = validator.service().models.head.fields.head
     tags.`type` should be("map[string]")
   }
 
   it("accept defaults for maps") {
     val json = baseJson.format("""{ "name": "tags", "type": "map", "default": "{ }" }""")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    val tags = validator.service.models.head.fields.head
+    validator.errors().mkString("") should be("")
+    val tags = validator.service().models.head.fields.head
     tags.default shouldBe Some("{ }")
   }
 
   it("validates invalid json") {
     val json = baseJson.format("""{ "name": "tags", "type": "map", "default": "bar" }""")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("default[bar] is not valid json")
+    validator.errors().mkString("") should be("default[bar] is not valid json")
   }
 
   it("accepts valid defaults for map[string]") {
     val json = baseJson.format("""{ "name": "tags", "type": "map[string]", "default": "{ \"foo\": \"bar\" }" }""")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
+    validator.errors().mkString("") should be("")
   }
 
   it("accepts valid defaults for map[integer]") {
     val json = baseJson.format("""{ "name": "tags", "type": "map[integer]", "default": "{ \"foo\": 1 }" }""")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
+    validator.errors().mkString("") should be("")
   }
 
   it("rejects invalid json objects for map[integer]") {
     val json = baseJson.format("""{ "name": "tags", "type": "map[integer]", "default": "1" }""")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("default[1] is not a valid JSON Object")
+    validator.errors().mkString("") should be("default[1] is not a valid JSON Object")
   }
 
   it("rejects invalid defaults for map[integer]") {
     val json = baseJson.format("""{ "name": "tags", "type": "map[integer]", "default": "{ \"foo\": \"bar\" }" }""")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("user.tags Value[bar] is not a valid integer")
+    validator.errors().mkString("") should be("user.tags Value[bar] is not a valid integer")
   }
 
   it("accepts valid defaults for list[string]") {
     val json = baseJson.format("""{ "name": "tags", "type": "[string]", "default": "[\"foo\", \"bar\"]" }""")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
+    validator.errors().mkString("") should be("")
   }
 
   it("accepts valid defaults for list[integer]") {
     val json = baseJson.format("""{ "name": "tags", "type": "[integer]", "default": "[1]" }""")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
+    validator.errors().mkString("") should be("")
   }
 
   it("rejects invalid json objects for list[integer]") {
     val json = baseJson.format("""{ "name": "tags", "type": "[integer]", "default": "1" }""")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("default[1] is not a valid JSON Array")
+    validator.errors().mkString("") should be("default[1] is not a valid JSON Array")
   }
 
   it("rejects invalid defaults for list[integer]") {
     val json = baseJson.format("""{ "name": "tags", "type": "[integer]", "default": "[\"bar\"]" }""")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("user.tags Value[bar] is not a valid integer")
+    validator.errors().mkString("") should be("user.tags Value[bar] is not a valid integer")
   }
 
 }

--- a/core/src/test/scala/core/ServiceMethodsSpec.scala
+++ b/core/src/test/scala/core/ServiceMethodsSpec.scala
@@ -30,7 +30,7 @@ class ServiceMethodsSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("Resource[user] /users Missing method")
+    validator.errors().mkString("") should be("Resource[user] /users Missing method")
   }
 
 }

--- a/core/src/test/scala/core/ServicePathParametersSpec.scala
+++ b/core/src/test/scala/core/ServicePathParametersSpec.scala
@@ -149,7 +149,7 @@ class ServicePathParametersSpec extends FunSpec with Matchers {
       val json = baseJson.format("guid")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
       validator.errors should be(Nil)
-      val userResource = validator.service.resources.head
+      val userResource = validator.service().resources.head
       val op = userResource.operations.head
       val param = op.parameters.head
       param.name should be("guid")
@@ -160,7 +160,7 @@ class ServicePathParametersSpec extends FunSpec with Matchers {
       val json = baseJson.format("age")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
       validator.errors should be(Nil)
-      val userResource = validator.service.resources.head
+      val userResource = validator.service().resources.head
       val op = userResource.operations.head
       val param = op.parameters.head
       param.name should be("age")
@@ -221,7 +221,7 @@ class ServicePathParametersSpec extends FunSpec with Matchers {
 
     val json = baseJson.format("age")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") shouldBe "Resource[user] GET /users path parameter[id] is missing from the path[/users]"
+    validator.errors().mkString("") shouldBe "Resource[user] GET /users path parameter[id] is missing from the path[/users]"
   }
 
   it("fails incorrectly named path parameters in the middle of the path") {
@@ -249,7 +249,7 @@ class ServicePathParametersSpec extends FunSpec with Matchers {
 
     val json = baseJson.format("age")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") shouldBe "Resource[user] GET /foo/:ids/bar path parameter[id] is missing from the path[/foo/:ids/bar]"
+    validator.errors().mkString("") shouldBe "Resource[user] GET /foo/:ids/bar path parameter[id] is missing from the path[/foo/:ids/bar]"
   }
 
   it("fails incorrectly named path parameters at the end of the path") {
@@ -277,6 +277,6 @@ class ServicePathParametersSpec extends FunSpec with Matchers {
 
     val json = baseJson.format("age")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") shouldBe "Resource[user] GET /foo/:ids path parameter[id] is missing from the path[/foo/:ids]"
+    validator.errors().mkString("") shouldBe "Resource[user] GET /foo/:ids path parameter[id] is missing from the path[/foo/:ids]"
   }
 }

--- a/core/src/test/scala/core/ServiceResourcesSpec.scala
+++ b/core/src/test/scala/core/ServiceResourcesSpec.scala
@@ -44,9 +44,9 @@ class ServiceResourcesSpec extends FunSpec with Matchers {
     it("models can be resources, with valid paths") {
       val json = baseJson.format("user")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("")
+      validator.errors().mkString("") should be("")
 
-      val resource = validator.service.resources.head
+      val resource = validator.service().resources.head
       val op = resource.operations.head
       op.path should be ("/users/:id")
     }
@@ -54,9 +54,9 @@ class ServiceResourcesSpec extends FunSpec with Matchers {
     it("enums can be resources, with valid paths") {
       val json = baseJson.format("user_type")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("")
+      validator.errors().mkString("") should be("")
 
-      val resource = validator.service.resources.head
+      val resource = validator.service().resources.head
       val op = resource.operations.head
       op.path should be ("/user_types/:id")
     }
@@ -64,13 +64,13 @@ class ServiceResourcesSpec extends FunSpec with Matchers {
     it("lists cannot be resources") {
       val json = baseJson.format("[user]")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("Resource[[user]] has an invalid type: must be a singleton (not a list nor map)")
+      validator.errors().mkString("") should be("Resource[[user]] has an invalid type: must be a singleton (not a list nor map)")
     }
 
     it("maps cannot be resources") {
       val json = baseJson.format("[user]")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("Resource[[user]] has an invalid type: must be a singleton (not a list nor map)")
+      validator.errors().mkString("") should be("Resource[[user]] has an invalid type: must be a singleton (not a list nor map)")
     }
 
   }
@@ -108,8 +108,8 @@ class ServiceResourcesSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    val operations = validator.service.resources.head.operations
+    validator.errors().mkString("") should be("")
+    val operations = validator.service().resources.head.operations
     operations.head.path should be("/")
     operations.last.path should be("/foo")
   }
@@ -145,13 +145,13 @@ class ServiceResourcesSpec extends FunSpec with Matchers {
     it("validates that resource types are well defined") {
       val json = baseJson.format("user")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("Resource[user] has an invalid type. Must resolve to a known enum, model or primitive")
+      validator.errors().mkString("") should be("Resource[user] has an invalid type. Must resolve to a known enum, model or primitive")
     }
 
     it("enums can be mapped to resources") {
       val json = baseJson.format("user_type")
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be("")
+      validator.errors().mkString("") should be("")
     }
 
   }

--- a/core/src/test/scala/core/ServiceResponsesSpec.scala
+++ b/core/src/test/scala/core/ServiceResponsesSpec.scala
@@ -39,61 +39,62 @@ class ServiceResponsesSpec extends FunSpec with Matchers {
     Seq(204, 304).foreach { code =>
       val json = baseJson.format("DELETE", s""", "responses": { "$code": { "type": "user" } } """)
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString("") should be(s"Resource[user] DELETE /users/:id response code[$code] must return unit and not[user]")
+      validator.errors().mkString("") should be(s"Resource[user] DELETE /users/:id response code[$code] must return unit and not[user]")
     }
   }
 
   it("verifies that response defaults to type 204 Unit") {
     val json = baseJson.format("DELETE", "")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    val response = validator.service.resources.head.operations.head.responses.find(r => TestHelper.responseCode(r.code) == "204").get
+    validator.errors() should be(Nil)
+    val response = validator.service().resources.head.operations.head.responses.find(r => TestHelper.responseCode(r.code) == "204").get
     response.`type` should be("unit")
   }
 
   it("validates that responses is map from string to object") {
     val json = baseJson.format("DELETE", s""", "responses": { "204": "unit" } """)
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString(" ") should be("Resource[user] DELETE /users/:id 204: value must be an object")
+    println(validator.errors().mkString(" "))
+    validator.errors().mkString(" ") should be("Resource[user] DELETE /users/:id 204: value must be an object")
   }
 
   it("generates an error message for an invalid method") {
     val json = baseJson.format("FOO", "")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString(" ") should be("Resource[user] FOO /users/:id Invalid HTTP method[FOO]. Must be one of: GET, POST, PUT, PATCH, DELETE, HEAD, CONNECT, OPTIONS, TRACE")
+    validator.errors().mkString(" ") should be("Resource[user] FOO /users/:id Invalid HTTP method[FOO]. Must be one of: GET, POST, PUT, PATCH, DELETE, HEAD, CONNECT, OPTIONS, TRACE")
   }
 
   it("accepts lower and upper case method names") {
     val lower = baseJson.format("get", "")
-    TestHelper.serviceValidatorFromApiJson(lower).errors.mkString(" ") should be("")
+    TestHelper.serviceValidatorFromApiJson(lower).errors().mkString(" ") should be("")
 
     val upper = baseJson.format("GET", "")
-    TestHelper.serviceValidatorFromApiJson(upper).errors.mkString(" ") should be("")
+    TestHelper.serviceValidatorFromApiJson(upper).errors().mkString(" ") should be("")
   }
 
   it("generates an error message for a missing method") {
     val json = baseJson.format("", "")
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString(" ") should be(s"Resource[user] /users/:id method must be a non empty string")
+    validator.errors().mkString(" ") should be(s"Resource[user] /users/:id method must be a non empty string")
   }
 
   it("supports 'default' keyword for response codes") {
     val json = baseJson.format("DELETE", s""", "responses": { "default": { "type": "error" } } """)
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString(" ") should be("")
+    validator.errors().mkString(" ") should be("")
   }
 
   it("validates strings that are not 'default'") {
     val json = baseJson.format("DELETE", s""", "responses": { "def": { "type": "error" } } """)
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString(" ") should be("Response code must be an integer or the keyword 'default' and not[def]")
+    validator.errors().mkString(" ") should be("Response code must be an integer or the keyword 'default' and not[def]")
   }
 
   it("validates response codes are >= 100") {
     Seq(-50, 0, 50).foreach { code =>
       val json = baseJson.format("DELETE", s""", "responses": { "$code": { "type": "error" } } """)
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      validator.errors.mkString(" ") should be(s"Response code[$code] must be >= 100")
+      validator.errors().mkString(" ") should be(s"Response code[$code] must be >= 100")
     }
   }
 
@@ -115,11 +116,10 @@ class ServiceResponsesSpec extends FunSpec with Matchers {
            |  }
            |}""".stripMargin)
       val validator = TestHelper.serviceValidatorFromApiJson(json)
-      val response = validator.service.resources.head.operations.head.responses.find(r => TestHelper.responseCode(r.code) == "422").get
+      val response = validator.service().resources.head.operations.head.responses.find(r => TestHelper.responseCode(r.code) == "422").get
       response.`type` should be("unit")
       response.attributes.get.head.name should be("user_errors")
       response.attributes.get.head.value shouldBe a [JsObject]
-
   }
 
 }

--- a/core/src/test/scala/core/ServiceValidatorSpec.scala
+++ b/core/src/test/scala/core/ServiceValidatorSpec.scala
@@ -7,12 +7,12 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
 
   it("should detect empty inputs") {
     val validator = TestHelper.serviceValidatorFromApiJson("")
-    validator.errors.mkString should be("No Data")
+    validator.errors().mkString should be("No Data")
   }
 
   it("should detect invalid json") {
     val validator = TestHelper.serviceValidatorFromApiJson(" { ")
-    validator.errors.mkString.indexOf("expected close marker") should be >= 0
+    validator.errors().mkString.indexOf("expected close marker") should be >= 0
   }
 
   it("service name must be a valid name") {
@@ -24,7 +24,7 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("Name[5@4] must start with a letter")
+    validator.errors().mkString should be("Name[5@4] must start with a letter")
   }
 
   it("base url shouldn't end with a '/'") {
@@ -38,7 +38,7 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("base_url[http://localhost:9000/] must not end with a '/'")
+    validator.errors().mkString should be("base_url[http://localhost:9000/] must not end with a '/'")
   }
 
   it("model that is missing fields") {
@@ -55,7 +55,7 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("Model[user] must have at least one field")
+    validator.errors().mkString should be("Model[user] must have at least one field")
   }
 
   it("model has a field with an invalid name") {
@@ -74,7 +74,7 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("Model[user] field name[_!@#] is invalid: Name can only contain a-z, A-Z, 0-9 and _ characters and Name must start with a letter")
+    validator.errors().mkString should be("Model[user] field name[_!@#] is invalid: Name can only contain a-z, A-Z, 0-9 and _ characters and Name must start with a letter")
   }
 
   it("model with duplicate field names") {
@@ -93,7 +93,7 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("Model[user] field[key] appears more than once")
+    validator.errors().mkString("") should be("Model[user] field[key] appears more than once")
   }
 
 
@@ -113,7 +113,7 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("user.foo has invalid type[foo]")
+    validator.errors().mkString should be("user.foo has invalid type[foo]")
   }
 
   it("types are lowercased in service definition") {
@@ -131,9 +131,9 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("")
+    validator.errors().mkString should be("")
 
-    validator.service.models.head.fields.head.`type` should be("uuid")
+    validator.service().models.head.fields.head.`type` should be("uuid")
   }
 
   it("base_url is optional") {
@@ -152,7 +152,7 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString should be("")
+    validator.errors().mkString should be("")
   }
 
   it("defaults to a NoContent response") {
@@ -181,8 +181,8 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    validator.service.resources.head.operations.head.responses.find(r => TestHelper.responseCode(r.code) == "204").getOrElse {
+    validator.errors().mkString("") should be("")
+    validator.service().resources.head.operations.head.responses.find(r => TestHelper.responseCode(r.code) == "204").getOrElse {
       sys.error("Missing 204 response")
     }
   }
@@ -216,8 +216,8 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json.format("string"))
-    validator.errors.mkString("") should be("")
-    val guid = validator.service.resources.head.operations.head.parameters.head
+    validator.errors().mkString("") should be("")
+    val guid = validator.service().resources.head.operations.head.parameters.head
     guid.`type` should be("string")
     guid.location should be(ParameterLocation.Header)
 
@@ -262,8 +262,8 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     val userHeader = header.format("user")
 
     val validator = TestHelper.serviceValidatorFromApiJson(json.format(stringHeader))
-    validator.errors.mkString("") should be("")
-    val headers = validator.service.resources.head.operations.head.responses.head.headers
+    validator.errors().mkString("") should be("")
+    val headers = validator.service().resources.head.operations.head.responses.head.headers
     headers.size should be(1)
     headers.get(0).name should be("foo")
     headers.get(0).`type` should be("string")
@@ -369,8 +369,8 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    val op = validator.service.resources.head.operations.head
+    validator.errors().mkString("") should be("")
+    val op = validator.service().resources.head.operations.head
     op.parameters.map(_.name) should be(Seq("guid"))
     val guid = op.parameters.head
     guid.`type` should be("uuid")
@@ -405,8 +405,8 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    val op = validator.service.resources.head.operations.head
+    validator.errors().mkString("") should be("")
+    val op = validator.service().resources.head.operations.head
     op.parameters.map(_.name) should be(Seq("guid"))
     val guid = op.parameters.head
     guid.`type` should be("[uuid]")
@@ -443,7 +443,7 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("Resource[user] GET /users/:id path parameter[id] is specified as optional. All path parameters are required")
+    validator.errors().mkString("") should be("Resource[user] GET /users/:id path parameter[id] is specified as optional. All path parameters are required")
   }
 
   it("infers datatype for a path parameter from the associated model") {
@@ -474,8 +474,8 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
-    val op = validator.service.resources.head.operations.head
+    validator.errors().mkString("") should be("")
+    val op = validator.service().resources.head.operations.head
     val idParam = op.parameters.head
     idParam.name should be("id")
     idParam.`type` should be("long")
@@ -521,7 +521,7 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
 
     it("maps of primitives are valid in query parameters") {
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("map[string]"))
-      validator.errors.mkString("") should be("Resource[tag] GET /tags Parameter[tags] has an invalid type[map[string]]. Maps are not supported as query parameters.")
+      validator.errors().mkString("") should be("Resource[tag] GET /tags Parameter[tags] has an invalid type[map[string]]. Maps are not supported as query parameters.")
     }
 
     it("lists of models are not valid in query parameters") {
@@ -533,12 +533,12 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
 
     it("models are not valid in query parameters") {
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("tag"))
-      validator.errors.mkString("") should be("Resource[tag] GET /tags Parameter[tags] has an invalid type[tag]. Model and union types are not supported as query parameters.")
+      validator.errors().mkString("") should be("Resource[tag] GET /tags Parameter[tags] has an invalid type[tag]. Model and union types are not supported as query parameters.")
     }
 
     it("validates type name in collection") {
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("[foo]"))
-      validator.errors.mkString("") should be("Resource[tag] GET /tags Parameter[tags] has an invalid type: [foo]")
+      validator.errors().mkString("") should be("Resource[tag] GET /tags Parameter[tags] has an invalid type: [foo]")
     }
 
   }
@@ -575,7 +575,7 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("")
+    validator.errors().mkString("") should be("")
   }
 
   it("resources with duplicate plural names are NOT allowed") {
@@ -617,6 +617,6 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     """
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("Resource with plural[users] appears more than once")
+    validator.errors().mkString("") should be("Resource with plural[users] appears more than once")
   }
 }

--- a/core/src/test/scala/core/UnionTypeSpec.scala
+++ b/core/src/test/scala/core/UnionTypeSpec.scala
@@ -64,7 +64,7 @@ class UnionTypeSpec extends FunSpec with Matchers {
     it("union types support descriptions") {
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("", "string", "uuid", "registered"))
       validator.errors should be(Nil)
-      val union = validator.service.unions.head
+      val union = validator.service().unions.head
       union.types.find(_.`type` == "string").get.description should be(Some("foobar"))
       union.types.find(_.`type` == "uuid").get.description should be(None)
     }
@@ -72,19 +72,19 @@ class UnionTypeSpec extends FunSpec with Matchers {
     it("union types can have primitives") {
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("", "string", "uuid", "registered"))
       validator.errors should be(Nil)
-      validator.service.unions.head.types.map(_.`type`) should be(Seq("string", "uuid"))
+      validator.service().unions.head.types.map(_.`type`) should be(Seq("string", "uuid"))
     }
 
     it("union types can have models") {
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("", "guest", "registered", "registered"))
       validator.errors should be(Nil)
-      validator.service.unions.head.types.map(_.`type`) should be(Seq("guest", "registered"))
+      validator.service().unions.head.types.map(_.`type`) should be(Seq("guest", "registered"))
     }
 
     it("union types can have lists") {
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("", "[guest]", "map[registered]", "registered"))
       validator.errors should be(Nil)
-      validator.service.unions.head.types.map(_.`type`) should be(Seq("[guest]", "map[registered]"))
+      validator.service().unions.head.types.map(_.`type`) should be(Seq("[guest]", "map[registered]"))
     }
 
     it("rejects blank types") {
@@ -114,14 +114,14 @@ class UnionTypeSpec extends FunSpec with Matchers {
 
     it("infers proper parameter type if field is common across all types") {
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("", "guest", "registered", "registered"))
-      validator.service.resources.head.operations.head.parameters.find(_.name == "id").getOrElse {
+      validator.service().resources.head.operations.head.parameters.find(_.name == "id").getOrElse {
         sys.error("Could not find guid parameter")
       }.`type` should be("uuid")
     }
 
     it("infers string parameter type if type varies") {
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format("", "other_random_user", "registered", "registered"))
-      validator.service.resources.head.operations.head.parameters.find(_.name == "id").getOrElse {
+      validator.service().resources.head.operations.head.parameters.find(_.name == "id").getOrElse {
         sys.error("Could not find guid parameter")
       }.`type` should be("string")
     }
@@ -133,7 +133,7 @@ class UnionTypeSpec extends FunSpec with Matchers {
     it("union types unique discriminator") {
       val validator = TestHelper.serviceValidatorFromApiJson(baseJson.format(""""discriminator": "type",""", "guest", "registered", "registered"))
       validator.errors should be(Nil)
-      val union = validator.service.unions.head
+      val union = validator.service().unions.head
       union.discriminator should be(Some("type"))
     }
 
@@ -251,7 +251,7 @@ class UnionTypeSpec extends FunSpec with Matchers {
 
 
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.service.resources.head.operations.head.parameters.find(_.name == "id").getOrElse {
+    validator.service().resources.head.operations.head.parameters.find(_.name == "id").getOrElse {
       sys.error("Could not find guid parameter")
     }.`type` should be("uuid")
   }
@@ -301,8 +301,8 @@ class UnionTypeSpec extends FunSpec with Matchers {
 
     val validator = TestHelper.serviceValidatorFromApiJson(common)
     validator.errors should be(Nil)
-    validator.service.namespace should be("test.common")
-    validator.service.models.map(_.name) should be(Seq("reference"))
+    validator.service().namespace should be("test.common")
+    validator.service().models.map(_.name) should be(Seq("reference"))
 
     val fetcher = MockServiceFetcher()
     fetcher.add(uri, validator.service)

--- a/core/src/test/scala/core/UtilSpec.scala
+++ b/core/src/test/scala/core/UtilSpec.scala
@@ -13,7 +13,7 @@ class UtilSpec extends FunSpec with Matchers {
   }
 
   it("isValidEnumValue") {
-    val service = TestHelper.parseFile(s"spec/apibuilder-api.json").service
+    val service = TestHelper.parseFile(s"spec/apibuilder-api.json").service()
     val visibilityEnum = service.enums.find(_.name == "visibility").getOrElse {
       sys.error("No visibility enum found")
     }

--- a/core/src/test/scala/core/builder/api_json/InternalDatatypeSpec.scala
+++ b/core/src/test/scala/core/builder/api_json/InternalDatatypeSpec.scala
@@ -4,27 +4,29 @@ import org.scalatest.{FunSpec, Matchers}
 
 class InternalDatatypeSpec extends FunSpec with Matchers {
 
+  private[this] val internalDatatypeBuilder = InternalDatatypeBuilder()
+
   it("label") {
     Seq("string", "uuid", "[string]", "[uuid]", "map[string]", "map[uuid]").foreach { name =>
-      val dt = InternalDatatype(name)
+      val dt = internalDatatypeBuilder.fromString(name).right.get
       dt.label should be(name)
       dt.required should be(true)
     }
   }
 
   it("map defaults to string type") {
-    InternalDatatype("map").label should be("map[string]")
+    internalDatatypeBuilder.fromString("map").right.get.label should be("map[string]")
   }
 
   it("handles malformed input") {
-    InternalDatatype("[").label should be("[")
+    internalDatatypeBuilder.fromString("[").right.get.label should be("[")
 
-    InternalDatatype("]").label should be("]")
+    internalDatatypeBuilder.fromString("]").right.get.label should be("]")
 
     // Questionable how best to handle this. For now we allow empty
     // string - will get caught downstream when validating that the
     // name of the datatype is a valid name
-    InternalDatatype("[]").label should be("[]")
+    internalDatatypeBuilder.fromString("[]").right.get.label should be("[]")
   }
 
 }

--- a/lib/src/main/scala/Primitives.scala
+++ b/lib/src/main/scala/Primitives.scala
@@ -16,9 +16,9 @@ object Primitives {
   case object Uuid extends Primitives { override def toString = "uuid" }
   case object Unit extends Primitives { override def toString = "unit" }
 
-  val All = Seq(Boolean, Decimal, Integer, Double, Long, Object, String, DateIso8601, DateTimeIso8601, Uuid, Unit)
+  val All: Seq[Primitives] = Seq(Boolean, Decimal, Integer, Double, Long, Object, String, DateIso8601, DateTimeIso8601, Uuid, Unit)
 
-  val ValidInPath = All.filter(p => p != Unit && p != Object)
+  val ValidInPath: Seq[Primitives] = All.filter(p => p != Unit && p != Object)
 
   def validInUrl(name: String): Boolean = {
     Primitives(name) match {
@@ -27,9 +27,8 @@ object Primitives {
     }
   }
 
-  def apply(value: String): Option[Primitives] = {
-    All.find(_.toString == value.toLowerCase.trim)
-  }
+  private[this] val byName: Map[String, Primitives] = All.map(x => x.toString.toLowerCase -> x).toMap
+
+  def apply(value: String): Option[Primitives] = byName.get(value.toLowerCase.trim)
 
 }
-


### PR DESCRIPTION
- This change allows user to declare types inline when using api.json format
  - Wherever we declare a type as the name of the model - we can now instead
    declare the type as an object, defining the enum, model or union inline
  - Tests have examples of varying inlining

  - Consider this feature experimental

As one example, this change allows you to define a model
that contains a single field named 'status' that is defined
as an enum named 'user_status'. Instead of having to declare
the enum itself, you can inline the enum into the definition
of the field:
```
    {
      "name": "Api Doc",

      "models": {
        "user": {
          "fields": [
            {
             "name": "status",
              "type": {
                "enum": "user_status",
                "values": [
                  { "name": "guest" },
                  { "name": "registered" }
                ]
              }
            }
          ]
        }
      }
    }
```

API Builder will automatically expand the type, creating the enum - ie. this feature
is to support human editing and does not change in any way the underling service specification.