### PR TITLE
Fix various example issues with enums and primitive unions

### DIFF
--- a/api/app/lib/ExampleJson.scala
+++ b/api/app/lib/ExampleJson.scala
@@ -52,10 +52,10 @@ case class ExampleJson(service: Service, selection: Selection) {
     parentUnionType(enum.name).fold(value) { case (union, unionType) =>
       // strip any namespace prefix from model name
       val name = enum.name.reverse.takeWhile(_ != '.').reverse
+      val discrVal = unionType.discriminatorValue.getOrElse(name)
       union.discriminator.fold {
-        Json.obj(name -> value)
+        Json.obj(discrVal -> value)
       }{ discriminator =>
-        val discrVal = unionType.discriminatorValue.getOrElse(name)
         Json.obj(
           discriminator -> JsString(discrVal),
           "value" -> value
@@ -79,10 +79,10 @@ case class ExampleJson(service: Service, selection: Selection) {
     parentUnionType(model.name).fold(value) { case (union, unionType) =>
       // strip any namespace prefix from model name
       val name = model.name.reverse.takeWhile(_ != '.').reverse
+      val discrVal = unionType.discriminatorValue.getOrElse(name)
       union.discriminator.fold {
-        Json.obj(name -> value)
+        Json.obj(discrVal -> value)
       }{ discriminator =>
-        val discrVal = unionType.discriminatorValue.getOrElse(name)
         Json.obj(discriminator -> JsString(discrVal)) ++ value
       }
     }
@@ -103,10 +103,10 @@ case class ExampleJson(service: Service, selection: Selection) {
 
   // primitives in a union type are wrapped in a 'value' field
   private[this] def primitiveUnionWrapper(union: Union, unionType: UnionType, js: JsValue): JsValue = {
+    val discrVal = unionType.discriminatorValue.getOrElse(unionType.`type`)
     union.discriminator.fold {
-      Json.obj(unionType.`type` -> Json.obj("value" -> js))
+      Json.obj(discrVal -> Json.obj("value" -> js))
     } { discriminator =>
-      val discrVal = unionType.discriminatorValue.getOrElse(unionType.`type`)
       Json.obj(
         discriminator -> JsString(discrVal),
         "value" -> js

--- a/api/app/lib/ExampleJson.scala
+++ b/api/app/lib/ExampleJson.scala
@@ -36,23 +36,28 @@ case class ExampleJson(service: Service, selection: Selection) {
     }
   }
 
-  private[this] def parentUnionType(typeName: String): Option[Union] = {
-    service.unions.find { u =>
-      u.types.map(_.`type`).contains(typeName)
-    }
+  private[this] def parentUnionType(typeName: String): Option[(Union, UnionType)] = {
+    (for {
+        union <- service.unions
+        unionType <- union.types if unionType.`type` == typeName
+      } yield union -> unionType
+    ).headOption
   }
 
   private[this] def makeEnum(enum: Enum): JsValue = {
     val value: JsValue = JsString(
-      enum.values.headOption.map(_.name.toString).getOrElse("undefined")
+      enum.values.headOption.map(ev => ev.value.getOrElse(ev.name)).getOrElse("undefined")
     )
 
-    parentUnionType(enum.name).fold(value) { union =>
+    parentUnionType(enum.name).fold(value) { case (union, unionType) =>
+      // strip any namespace prefix from model name
+      val name = enum.name.reverse.takeWhile(_ != '.').reverse
       union.discriminator.fold {
-        Json.obj(enum.name -> value)
+        Json.obj(name -> value)
       }{ discriminator =>
+        val discrVal = unionType.discriminatorValue.getOrElse(name)
         Json.obj(
-          discriminator -> JsString(enum.name),
+          discriminator -> JsString(discrVal),
           "value" -> value
         )
       }
@@ -71,13 +76,14 @@ case class ExampleJson(service: Service, selection: Selection) {
       )
     )
 
-    parentUnionType(model.name).fold(value) { union =>
+    parentUnionType(model.name).fold(value) { case (union, unionType) =>
       // strip any namespace prefix from model name
       val name = model.name.reverse.takeWhile(_ != '.').reverse
       union.discriminator.fold {
         Json.obj(name -> value)
       }{ discriminator =>
-        Json.obj(discriminator -> JsString(name)) ++ value
+        val discrVal = unionType.discriminatorValue.getOrElse(name)
+        Json.obj(discriminator -> JsString(discrVal)) ++ value
       }
     }
   }
@@ -85,23 +91,24 @@ case class ExampleJson(service: Service, selection: Selection) {
   private[this] def makeUnion(union: Union): JsValue = {
     union.types.headOption.fold {
       Json.obj(): JsValue
-    } { typ =>
-      mockValue(TextDatatype.parse(typ.`type`)) match {
-        case js: JsBoolean => primitiveUnionWrapper(union, js)
-        case js: JsNumber => primitiveUnionWrapper(union, js)
-        case js: JsString => primitiveUnionWrapper(union, js)
+    } { unionType =>
+      mockValue(TextDatatype.parse(unionType.`type`)) match {
+        case js: JsBoolean => primitiveUnionWrapper(union, unionType, js)
+        case js: JsNumber => primitiveUnionWrapper(union, unionType, js)
+        case js: JsString => primitiveUnionWrapper(union, unionType, js)
         case other => other
       }
     }
   }
 
   // primitives in a union type are wrapped in a 'value' field
-  private[this] def primitiveUnionWrapper(union: Union, js: JsValue): JsValue = {
+  private[this] def primitiveUnionWrapper(union: Union, unionType: UnionType, js: JsValue): JsValue = {
     union.discriminator.fold {
-      Json.obj("value" -> js)
+      Json.obj(unionType.`type` -> Json.obj("value" -> js))
     } { discriminator =>
+      val discrVal = unionType.discriminatorValue.getOrElse(unionType.`type`)
       Json.obj(
-        discriminator -> union.name,
+        discriminator -> JsString(discrVal),
         "value" -> js
       )
     }

--- a/api/app/lib/ServiceBuilder.scala
+++ b/api/app/lib/ServiceBuilder.scala
@@ -1,0 +1,92 @@
+package lib
+
+import io.apibuilder.spec.v0.models.{Enum, EnumValue, Field, Model, Service, Union, UnionType}
+
+object ServiceBuilder {
+  implicit class ServiceBuilder(val service: Service) extends AnyVal {
+
+    def withModel(name: String,
+                  modelTaylor: Model => Model = identity): Service = {
+      val model = Model(
+        name = name,
+        plural = s"${name}s",
+        fields = Nil
+      )
+
+      service.copy(
+        models = service.models ++ Seq(modelTaylor(model))
+      )
+    }
+
+    def withEnum(name: String,
+                 enumTailor: Enum => Enum = identity): Service = {
+      val enum = Enum(
+        name = name,
+        plural = s"${name}s",
+        values = Nil
+      )
+
+      service.copy(
+        enums = service.enums ++ Seq(enumTailor(enum))
+      )
+    }
+
+    def withUnion(name: String,
+                  unionTailor: Union => Union = identity,
+                  discriminator: Option[String] = None): Service = {
+      val union = Union(
+        name = name,
+        plural = s"${name}s",
+        discriminator = discriminator,
+        types = Nil
+      )
+      service.copy(
+        unions = service.unions ++ Seq(unionTailor(union))
+      )
+    }
+  }
+
+  implicit class ModelBuilder(val model: Model) extends AnyVal {
+    def withField(name: String,
+                  fieldType: String,
+                  default: Option[String] = None,
+                  required: Boolean = true): Model = {
+      val field = Field(
+        name = name,
+        `type` = fieldType,
+        default = default,
+        required = required)
+      model.copy(fields = model.fields ++ Seq(field))
+    }
+
+  }
+
+  implicit class EnumBuilder(val enum: Enum) extends AnyVal {
+    def withValue(name: String,
+                  value: Option[String] = None): Enum = {
+      val enumValue = EnumValue(
+        name = name,
+        value = value
+      )
+      enum.copy(
+        values = enum.values ++ Seq(enumValue)
+      )
+    }
+
+  }
+
+  implicit class UnionBuilder(val union: Union) extends AnyVal {
+    def withType(`type`: String,
+                 discriminatorValue: Option[String] = None,
+                 isDefault: Boolean = false): Union = {
+      val unionType = UnionType(
+        `type` = `type`,
+        default = Some(true).filter(_ => isDefault),
+        discriminatorValue = discriminatorValue
+      )
+      union.copy(
+        types = union.types ++ Seq(unionType)
+      )
+    }
+  }
+}

--- a/api/test/lib/ExampleJsonSpec.scala
+++ b/api/test/lib/ExampleJsonSpec.scala
@@ -8,7 +8,7 @@ import play.api.libs.json.{JsString, Json}
 class ExampleJsonSpec extends FunSpec with ShouldMatchers with util.TestApplication {
   import ServiceBuilder._
 
-  private[this] lazy val service: Service = TestHelper.readService("../spec/apibuilder-spec.json")
+  private[this] lazy val service: Service = TestHelper.readService("/web/apibuilder/apibuilder/spec/apibuilder-spec.json")
   private[this] lazy val exampleAll = ExampleJson.allFields(service)
   private[this] lazy val exampleMinimal = ExampleJson.requiredFieldsOnly(service)
 
@@ -85,6 +85,16 @@ class ExampleJsonSpec extends FunSpec with ShouldMatchers with util.TestApplicat
     ExampleJson.allFields(svc).sample("dimension").get should equal(
       Json.obj(
         "color" -> "red"
+      )
+    )
+  }
+
+  it("union type (no discriminator but with discriminator value) containing an enum") {
+    val svc = service.withEnum("color", _.withValue("red")).withUnion("dimension", _.withType("color", Some("farbe")))
+
+    ExampleJson.allFields(svc).sample("dimension").get should equal(
+      Json.obj(
+        "farbe" -> "red"
       )
     )
   }
@@ -166,6 +176,18 @@ class ExampleJsonSpec extends FunSpec with ShouldMatchers with util.TestApplicat
     )
   }
 
+  it("union type (no discriminator but with discriminator value) containing a model") {
+    val svc = service.withModel("user", _.withField("name", "string", Some("Joe"))).withUnion("party", _.withType("user", Some("usr")))
+
+    ExampleJson.allFields(svc).sample("party").get should equal(
+      Json.obj(
+        "usr" -> Json.obj(
+          "name" -> "Joe"
+        )
+      )
+    )
+  }
+
   it("union type (w/ discriminator) containing a model") {
     val svc = service.withModel("user", _.withField("name", "string", Some("Joe"))).withUnion("party", _.withType("user"), Some("discriminator"))
 
@@ -205,6 +227,16 @@ class ExampleJsonSpec extends FunSpec with ShouldMatchers with util.TestApplicat
     ExampleJson.allFields(svc).sample("primitive").get should equal(
       Json.obj(
         "integer" -> Json.obj("value" -> 1)
+      )
+    )
+  }
+
+  it("union type (no discriminator but with discriminator value) containing a primitive") {
+    val svc = service.withUnion("primitive", _.withType("integer", Some("int")))
+
+    ExampleJson.allFields(svc).sample("primitive").get should equal(
+      Json.obj(
+        "int" -> Json.obj("value" -> 1)
       )
     )
   }

--- a/api/test/lib/ExampleJsonSpec.scala
+++ b/api/test/lib/ExampleJsonSpec.scala
@@ -8,7 +8,7 @@ import play.api.libs.json.{JsString, Json}
 class ExampleJsonSpec extends FunSpec with ShouldMatchers with util.TestApplication {
   import ServiceBuilder._
 
-  private[this] lazy val service: Service = TestHelper.readService("/web/apibuilder/apibuilder/spec/apibuilder-spec.json")
+  private[this] lazy val service: Service = TestHelper.readService("../spec/apibuilder-spec.json")
   private[this] lazy val exampleAll = ExampleJson.allFields(service)
   private[this] lazy val exampleMinimal = ExampleJson.requiredFieldsOnly(service)
 


### PR DESCRIPTION
* Use EnumValue 'value' instead of 'name' if available
* Use UnionType 'discriminatorValue' instead of 'type' if available
* Strip namespace from enum types
* Primitives in union without discriminator should be { `type`: { "value" : `value` } }
* Primitives in union with discriminator should use type instead of union name as discriminator