### PR TITLE
Only include discriminator in union example, not in model or enum

### DIFF
--- a/api/app/lib/ExampleJson.scala
+++ b/api/app/lib/ExampleJson.scala
@@ -145,7 +145,7 @@ case class ExampleJson(service: Service, selection: Selection) {
     val types = TextDatatype.parse(field.`type`)
     types.toList match {
       case Nil => JsNull
-      case TextDatatype.Singleton(one) :: Nil => singleton(field, None)
+      case TextDatatype.Singleton(one) :: Nil => singleton(field)
       case TextDatatype.Singleton(_) :: _ => sys.error("Singleton must be leaf")
       case TextDatatype.List :: rest => {
         field.default match {
@@ -178,14 +178,14 @@ case class ExampleJson(service: Service, selection: Selection) {
     }
   }
 
-  private[this] def singleton(field: Field, parentUnion: Option[(Union, UnionType)]): JsValue = {
+  private[this] def singleton(field: Field): JsValue = {
     Primitives(field.`type`) match {
       case None => {
         service.enums.find(_.name == field.`type`) match {
-          case Some(e) => JsString(e.values.headOption.map(_.name).getOrElse("undefined"))
+          case Some(e) => makeEnum(e, None)
           case None => {
             service.models.find(_.name == field.`type`) match {
-              case Some(m) => makeModel(m, parentUnion)
+              case Some(m) => makeModel(m, None)
               case None => {
                 service.unions.find(_.name == field.`type`) match {
                   case Some(u) => makeUnion(u)

--- a/api/test/lib/ExampleJsonSpec.scala
+++ b/api/test/lib/ExampleJsonSpec.scala
@@ -3,7 +3,7 @@ package lib
 import io.apibuilder.spec.v0.models._
 import io.apibuilder.spec.v0.models.json._
 import org.scalatest.{FunSpec, ShouldMatchers}
-import play.api.libs.json.{JsArray, JsNull, JsNumber, JsString, Json}
+import play.api.libs.json.{JsNull, JsNumber, JsString, Json}
 
 class ExampleJsonSpec extends FunSpec with ShouldMatchers with util.TestApplication {
   import ServiceBuilder._

--- a/api/test/lib/ExampleJsonSpec.scala
+++ b/api/test/lib/ExampleJsonSpec.scala
@@ -8,7 +8,7 @@ import play.api.libs.json.{JsArray, JsNull, JsNumber, JsString, Json}
 class ExampleJsonSpec extends FunSpec with ShouldMatchers with util.TestApplication {
   import ServiceBuilder._
 
-  private[this] lazy val service: Service = TestHelper.readService("/web/apibuilder/apibuilder/spec/apibuilder-spec.json")
+  private[this] lazy val service: Service = TestHelper.readService("../spec/apibuilder-spec.json")
   private[this] lazy val exampleAll = ExampleJson.allFields(service)
   private[this] lazy val exampleMinimal = ExampleJson.requiredFieldsOnly(service)
 

--- a/api/test/lib/ExampleJsonSpec.scala
+++ b/api/test/lib/ExampleJsonSpec.scala
@@ -82,6 +82,10 @@ class ExampleJsonSpec extends FunSpec with ShouldMatchers with util.TestApplicat
   it("union type (no discriminator) containing an enum") {
     val svc = service.withEnum("color", _.withValue("red")).withUnion("dimension", _.withType("color"))
 
+    ExampleJson.allFields(svc).sample("color").get should equal(
+      JsString("red")
+    )
+
     ExampleJson.allFields(svc).sample("dimension").get should equal(
       Json.obj(
         "color" -> "red"
@@ -101,6 +105,10 @@ class ExampleJsonSpec extends FunSpec with ShouldMatchers with util.TestApplicat
 
   it("union type (w/ discriminator) containing an enum") {
     val svc = service.withEnum("color", _.withValue("red")).withUnion("dimension", _.withType("color"), Some("discriminator"))
+
+    ExampleJson.allFields(svc).sample("color").get should equal(
+      JsString("red")
+    )
 
     ExampleJson.allFields(svc).sample("dimension").get should equal(
       Json.obj(
@@ -167,6 +175,12 @@ class ExampleJsonSpec extends FunSpec with ShouldMatchers with util.TestApplicat
   it("union type (no discriminator) containing a model") {
     val svc = service.withModel("user", _.withField("name", "string", Some("Joe"))).withUnion("party", _.withType("user"))
 
+    ExampleJson.allFields(svc).sample("user").get should equal(
+      Json.obj(
+        "name" -> "Joe"
+      )
+    )
+
     ExampleJson.allFields(svc).sample("party").get should equal(
       Json.obj(
         "user" -> Json.obj(
@@ -190,6 +204,12 @@ class ExampleJsonSpec extends FunSpec with ShouldMatchers with util.TestApplicat
 
   it("union type (w/ discriminator) containing a model") {
     val svc = service.withModel("user", _.withField("name", "string", Some("Joe"))).withUnion("party", _.withType("user"), Some("discriminator"))
+
+    ExampleJson.allFields(svc).sample("user").get should equal(
+      Json.obj(
+        "name" -> "Joe"
+      )
+    )
 
     ExampleJson.allFields(svc).sample("party").get should equal(
       Json.obj(


### PR DESCRIPTION
The discriminator should only be displayed when a model or enum is viewed as the member of a union, not when it's viewed on its own.