### PR TITLE
Default user agent to use '-' instead of ':'

### DIFF
--- a/api/app/controllers/Code.scala
+++ b/api/app/controllers/Code.scala
@@ -55,7 +55,7 @@ class Code @Inject() (
                 Future.successful(Conflict(Json.toJson(Validation.error(s"Generator with key[$generatorKey] not found"))))
               }
               case Some(gws) => {
-                val userAgent = s"apibuilder:$apibuilderVersion ${AppConfig.apibuilderWwwHost}/${orgKey}/${applicationKey}/${version.version}/${gws.generator.key}"
+                val userAgent = s"apibuilder-$apibuilderVersion ${AppConfig.apibuilderWwwHost}/${orgKey}/${applicationKey}/${version.version}/${gws.generator.key}"
 
                 val attributes = getAllAttributes(version.organization.guid, gws.generator.attributes)
 


### PR DESCRIPTION
- See https://github.com/apicollective/apibuilder-generator/pull/344
 - Fixes:
```
 Illegal header: Illegal 'user-agent' header: Invalid input ':', expected
    OWS, 'EOI', tchar, product-or-comment, comment or ws (line 1, column 11):
    apibuilder:0.12.87
    https://app.apibuilder.io/flow/api/0.4.14/ning_1_9_client
```