### PR TITLE
Relaxing validation to permit optional fields to have defaults

### DIFF
--- a/core/src/main/scala/core/builder/ServiceSpecValidator.scala
+++ b/core/src/main/scala/core/builder/ServiceSpecValidator.scala
@@ -456,10 +456,7 @@ case class ServiceSpecValidator(
     service.models.flatMap { model =>
       model.fields.flatMap { field =>
         field.default.flatMap { default =>
-          field.required match {
-            case false => Some(s"${model.name}.${field.name} has a default specified. It must be marked required")
-            case true => validateDefault(s"${model.name}.${field.name}", field.`type`, default)
-          }
+          validateDefault(s"${model.name}.${field.name}", field.`type`, default)
         }
       }
     } match {

--- a/core/src/test/scala/core/ServiceDefaultsSpec.scala
+++ b/core/src/test/scala/core/ServiceDefaultsSpec.scala
@@ -70,8 +70,9 @@ class ServiceDefaultsSpec extends FunSpec with Matchers {
     validator.errors().mkString("") should be("user.is_active Value[1] is not a valid boolean. Must be one of: true, false")
   }
 
-  it("fields with defaults must be marked required") {
-    val json = """
+  it("fields with defaults may be marked optional") {
+    val jsonOpt =
+      """
     {
       "name": "Api Doc",
       "apidoc": { "version": "0.9.6" },
@@ -85,8 +86,28 @@ class ServiceDefaultsSpec extends FunSpec with Matchers {
       }
     }
     """
-    val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors().mkString("") should be("user.created_at has a default specified. It must be marked required")
+    val validator = TestHelper.serviceValidatorFromApiJson(jsonOpt)
+    validator.errors().mkString("") should be("")
+  }
+
+  it("fields with defaults may be marked required") {
+    val jsonReq = """
+    {
+      "name": "Api Doc",
+      "apidoc": { "version": "0.9.6" },
+
+      "models": {
+        "user": {
+          "fields": [
+            { "name": "created_at", "type": "date-iso8601", "default": "2014-01-01", "required": true }
+          ]
+        }
+      }
+    }
+    """
+
+    val validator = TestHelper.serviceValidatorFromApiJson(jsonReq)
+    validator.errors().mkString("") should be("")
   }
 
   def buildMinMaxErrors(


### PR DESCRIPTION
This is dependent on https://github.com/apicollective/apibuilder-generator/pull/378 
(which introduces "receiver" - side defaulting, without which the use of optional+default will result in code generation failures) and is a dependency of 
https://github.com/apicollective/apibuilder/pull/739 (which uses the new defaulting
behavior to introduce a new first level concern to the API Builder service spec).