### PR TITLE
Carry Swagger vendor extensions through to attributes

### DIFF
--- a/swagger/src/main/scala/me/apidoc/swagger/Parser.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/Parser.scala
@@ -64,7 +64,7 @@ case class Parser(config: ServiceConfiguration) {
             host = swagger.getHost,
             basePath = swagger.getBasePath
           ).toAttribute
-        ).flatten
+        ).flatten ++ Util.vendorExtensionsToAttributes(swagger.getVendorExtensions)
     )
   }
 

--- a/swagger/src/main/scala/me/apidoc/swagger/translators/Body.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/translators/Body.scala
@@ -3,6 +3,7 @@ package me.apidoc.swagger.translators
 import io.apibuilder.spec.v0.{ models => apidoc }
 import io.swagger.models.{ModelImpl, RefModel}
 import io.swagger.models.{ parameters => swaggerParams }
+import me.apidoc.swagger.Util
 
 object Body {
 
@@ -19,7 +20,8 @@ object Body {
     apidoc.Body(
       `type` = bodyType,
       description = Option(param.getDescription),
-      deprecation = None
+      deprecation = None,
+      attributes = Util.vendorExtensionsToAttributes(param.getVendorExtensions)
     )
   }
 

--- a/swagger/src/main/scala/me/apidoc/swagger/translators/Field.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/translators/Field.scala
@@ -23,7 +23,8 @@ object Field {
       `type` = resolver.schemaType(prop),
       description = Option(prop.getDescription),
       required = prop.getRequired(),
-      example = Option(prop.getExample()).map(_.toString)
+      example = Option(prop.getExample()).map(_.toString),
+      attributes = Util.vendorExtensionsToAttributes(prop.getVendorExtensions)
     )
     specialize(base, prop, modelName)
   }

--- a/swagger/src/main/scala/me/apidoc/swagger/translators/Model.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/translators/Model.scala
@@ -46,7 +46,7 @@ object Model {
               SwaggerData(
                 externalDocs = m.getExternalDocs,
                 example = m.getExample).toAttribute)
-              .flatten
+              .flatten ++ Util.vendorExtensionsToAttributes(m.getVendorExtensions)
         )), enums(m, name))
     }
   }

--- a/swagger/src/main/scala/me/apidoc/swagger/translators/Operation.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/translators/Operation.scala
@@ -70,7 +70,7 @@ object Operation {
             operationId = op.getOperationId,
             tags = op.getTags
           ).toAttribute
-        ).flatten
+        ).flatten ++ Util.vendorExtensionsToAttributes(op.getVendorExtensions)
     )
   }
 

--- a/swagger/src/main/scala/me/apidoc/swagger/translators/Response.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/translators/Response.scala
@@ -2,6 +2,7 @@ package me.apidoc.swagger.translators
 
 import lib.Primitives
 import io.apibuilder.spec.v0.{ models => apidoc }
+import me.apidoc.swagger.Util
 import io.swagger.{ models => swagger }
 
 object Response {
@@ -27,7 +28,8 @@ object Response {
         case Some(schema) => resolver.schemaType(schema)
       },
       description = Option(response.getDescription),
-      deprecation = None
+      deprecation = None,
+      attributes = Util.vendorExtensionsToAttributesOpt(response.getVendorExtensions)
     )
   }
 

--- a/swagger/src/test/resources/petstore-enums.json
+++ b/swagger/src/test/resources/petstore-enums.json
@@ -110,6 +110,9 @@
               "x-expires": {
                 "type": "string"
               }
+            },
+            "x-foo-response": {
+              "bar": "response"
             }
           },
           "default": {
@@ -118,6 +121,9 @@
               "$ref": "#/definitions/Error"
             }
           }
+        },
+        "x-foo-operation": {
+          "bar": "operation"
         }
       }
     }
@@ -138,12 +144,18 @@
           "type": "string"
         },
         "tag": {
-          "type": "string"
+          "type": "string",
+          "x-foo-field": {
+            "bar": "field"
+          }
         },
         "status": {
           "type": "string",
           "enum": ["available", "pending", "sold"]
         }
+      },
+      "x-foo-model": {
+        "bar": "model"
       }
     },
     "Error": {
@@ -161,5 +173,8 @@
         }
       }
     }
+  },
+  "x-foo-service": {
+    "bar": "service"
   }
 }

--- a/swagger/src/test/resources/petstore-external-docs-example-security.json
+++ b/swagger/src/test/resources/petstore-external-docs-example-security.json
@@ -119,6 +119,9 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/newPet"
+            },
+            "x-foo-body": {
+              "bar": "body"
             }
           }
         ],

--- a/swagger/src/test/scala/me/apidoc/swagger/SwaggerServiceValidatorSpec.scala
+++ b/swagger/src/test/scala/me/apidoc/swagger/SwaggerServiceValidatorSpec.scala
@@ -68,7 +68,11 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                     ("schemes", JsArray(Seq(JsString("http")))),
                     ("host", JsString("petstore.swagger.wordnik.com")),
                     ("basePath", JsString("/api"))
-                  )))))
+                  ))),
+                  Attribute(
+                    name = "foo-service",
+                    value = JsObject(Seq(("bar", JsString("service"))))
+                  )))
 
               service.models.map(_.name).sorted should be(Seq("Error", "Pet"))
               checkModel(
@@ -91,14 +95,22 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                     Field(
                       name = "tag",
                       `type` = "string",
-                      required = false
+                      required = false,
+                      attributes = Seq(Attribute(
+                        name = "foo-field",
+                        value = JsObject(Seq(("bar", JsString("field"))))
+                      ))
                     ),
                     Field(
                       name = "status",
                       `type` = "PetStatus",
                       required = false
                     )
-                  )
+                  ),
+                  attributes = Seq(Attribute(
+                    name = "foo-model",
+                    value = JsObject(Seq(("bar", JsString("model"))))
+                  ))
                 )
               )
 
@@ -132,6 +144,62 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                   description = None,
                   deprecation = None,
                   operations = Seq(
+                    Operation(
+                      method = Get,
+                      path = "/pets/",
+                      description = Some("find pets by name and status - as query params"),
+                      deprecation = None,
+                      body = None,
+                      parameters = Seq(
+                        Parameter(
+                          name = "name",
+                          `type` = "string",
+                          location = Query,
+                          description = None,
+                          deprecation = None,
+                          required = true,
+                          default = None,
+                          minimum = None,
+                          maximum = None,
+                          example = None),
+                        Parameter(
+                          name = "status",
+                          `type` = "PetStatusGetQuery",
+                          location = Query,
+                          description = None,
+                          deprecation = None,
+                          required = true,
+                          default = None,
+                          minimum = None,
+                          maximum = None,
+                          example = None)
+                      ),
+                      responses = Seq(
+                        Response(
+                          code = ResponseCodeInt(200),
+                          `type` = "[Pet]",
+                          description = Some("find pet response"),
+                          deprecation = None,
+                          attributes = Some(Seq(Attribute(
+                            name = "foo-response",
+                            value = JsObject(Seq(("bar", JsString("response"))))
+                          )))),
+                        Response(
+                          code = ResponseCodeOption.Default,
+                          `type` = "Error",
+                          description = Some("unexpected error"),
+                          deprecation = None)
+                      ),
+                      attributes =  Seq(Attribute(
+                        name = SwaggerData.AttributeName,
+                        description = Some(SwaggerData.AttributeDescription),
+                        value = JsObject(Seq(
+                          ("summary", JsString("find pets by name and status - as query params"))
+                        ))),
+                        Attribute(
+                          name = "foo-operation",
+                          value = JsObject(Seq(("bar", JsString("operation"))))
+                        ))),
                     Operation(
                       method = Get,
                       path = "/pets/:status",
@@ -202,57 +270,9 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                         name = SwaggerData.AttributeName,
                         description = Some(SwaggerData.AttributeDescription),
                         value = JsObject(Seq(
+                          ("tags", JsArray(Seq(JsString("tag1"), JsString("tag2")))),
                           ("summary", JsString("delete pets by status - as a path param")),
-                          ("operationId", JsString("deletePet")),
-                          ("tags", JsArray(Seq(JsString("tag1"), JsString("tag2"))))
-                        ))))),
-                    Operation(
-                      method = Get,
-                      path = "/pets/",
-                      description = Some("find pets by name and status - as query params"),
-                      deprecation = None,
-                      body = None,
-                      parameters = Seq(
-                        Parameter(
-                          name = "name",
-                          `type` = "string",
-                          location = Query,
-                          description = None,
-                          deprecation = None,
-                          required = true,
-                          default = None,
-                          minimum = None,
-                          maximum = None,
-                          example = None),
-                        Parameter(
-                          name = "status",
-                          `type` = "PetStatusGetQuery",
-                          location = Query,
-                          description = None,
-                          deprecation = None,
-                          required = true,
-                          default = None,
-                          minimum = None,
-                          maximum = None,
-                          example = None)
-                      ),
-                      responses = Seq(
-                        Response(
-                          code = ResponseCodeInt(200),
-                          `type` = "[Pet]",
-                          description = Some("find pet response"),
-                          deprecation = None),
-                        Response(
-                          code = ResponseCodeOption.Default,
-                          `type` = "Error",
-                          description = Some("unexpected error"),
-                          deprecation = None)
-                      ),
-                      attributes =  Seq(Attribute(
-                        name = SwaggerData.AttributeName,
-                        description = Some(SwaggerData.AttributeDescription),
-                        value = JsObject(Seq(
-                          ("summary", JsString("find pets by name and status - as query params"))
+                          ("operationId", JsString("deletePet"))
                         )))))
                   ),
                   attributes = Seq())

--- a/swagger/src/test/scala/me/apidoc/swagger/UtilSpec.scala
+++ b/swagger/src/test/scala/me/apidoc/swagger/UtilSpec.scala
@@ -1,6 +1,7 @@
 package me.apidoc.swagger
 
 import org.scalatest.{FunSpec, Matchers}
+import play.api.libs.json._
 
 class UtilSpec extends FunSpec with Matchers {
 
@@ -38,6 +39,20 @@ class UtilSpec extends FunSpec with Matchers {
     Util.choose(Some("a"), None) should be(Some("a"))
     Util.choose(Some("a"), Some("b")) should be(Some("a"))
     Util.choose(None, Some("b")) should be(Some("b"))
+  }
+
+  it("swaggerAnyToJsValue") {
+    import collection.JavaConverters._
+    case class Unsupported(foo: String)
+    Util.swaggerAnyToJsValue("foo") should be(JsString("foo"))
+    Util.swaggerAnyToJsValue(false) should be(JsFalse)
+    Util.swaggerAnyToJsValue(true) should be(JsTrue)
+    Util.swaggerAnyToJsValue(1.3) should be(JsNumber(BigDecimal(1.3)))
+    Util.swaggerAnyToJsValue(1) should be(JsNumber(BigDecimal(1)))
+    Util.swaggerAnyToJsValue(1.3f) should be(JsNumber(BigDecimal(1.3f)))
+    Util.swaggerAnyToJsValue(Seq("foo", 1, Seq("bar").asJava).asJava) should be(JsArray(Seq(JsString("foo"), JsNumber(BigDecimal(1)), JsArray(Seq(JsString("bar"))))))
+    Util.swaggerAnyToJsValue(Map("foo" -> 1, "bar" -> Seq("baz", 1.3).asJava).asJava) should be(JsObject(Seq("foo" -> JsNumber(BigDecimal(1)), "bar" -> JsArray(Seq(JsString("baz"), JsNumber(BigDecimal(1.3)))))))
+    Util.swaggerAnyToJsValue(Unsupported("bar")) should be(JsNull)
   }
 
   it("toOption") {


### PR DESCRIPTION
Per Swagger 2.0 docs:
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#vendorExtensions

Many properties of the Swagger doc can include a free-form 'x-'-prefixed attribute.
These can be stored in the attributes for the corresponding Apibuilder model.