### PR TITLE
Don't generate . in CSS class name

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -60,6 +60,7 @@ You'll need to run the postgresql database (version 9.5 or greater). Two options
   1. docker run -d -p 5432:5432 flowcommerce/apibuilder-postgresql:latest
 
   2. run locally - see the project https://github.com/apicollective/apibuilder-postgresql
+     - You need to run `psql -U api apibuilderdb ./setup-test-data.sql` to get the `dev` user
 
 The application consists of a service on port 9001, and a web app on port 9000.
 

--- a/lib/src/main/scala/UrlKey.scala
+++ b/lib/src/main/scala/UrlKey.scala
@@ -5,7 +5,7 @@ object UrlKey {
   private[this] val MinKeyLength = 3
 
   // Only want lower case letters and dashes
-  private[this] val Regexp1 = """([^0-9a-z\-\_\.])""".r
+  private[this] val Regexp1 = """([^0-9a-z\-\_])""".r
 
   // Turn multiple dashes into single dashes
   private[this] val Regexp2 = """(\-+)""".r


### PR DESCRIPTION
Fixes cases like https://app.apibuilder.io/flow/user/latest, where you cannot expand the operations because the class name contains a `.`, since the user model is imported from common