### PR TITLE
include imported services in the Apibuilder code generator invocation

### DIFF
--- a/api/app/generated/ApicollectiveApibuilderGeneratorV0Parsers.scala
+++ b/api/app/generated/ApicollectiveApibuilderGeneratorV0Parsers.scala
@@ -176,16 +176,19 @@ package io.apibuilder.generator.v0.anorm.parsers {
       servicePrefix: String = "service",
       attributes: String = "attributes",
       userAgent: String = "user_agent",
+      importedServices: String = "imported_services",
       prefixOpt: Option[String] = None
     ): RowParser[io.apibuilder.generator.v0.models.InvocationForm] = {
       io.apibuilder.spec.v0.anorm.parsers.Service.parserWithPrefix(prefixOpt.getOrElse("") + servicePrefix) ~
       SqlParser.get[Seq[io.apibuilder.generator.v0.models.Attribute]](prefixOpt.getOrElse("") + attributes) ~
-      SqlParser.str(prefixOpt.getOrElse("") + userAgent).? map {
-        case service ~ attributes ~ userAgent => {
+      SqlParser.str(prefixOpt.getOrElse("") + userAgent).? ~
+      SqlParser.get[Seq[io.apibuilder.spec.v0.models.Service]](prefixOpt.getOrElse("") + importedServices).? map {
+        case service ~ attributes ~ userAgent ~ importedServices => {
           io.apibuilder.generator.v0.models.InvocationForm(
             service = service,
             attributes = attributes,
-            userAgent = userAgent
+            userAgent = userAgent,
+            importedServices = importedServices
           )
         }
       }

--- a/api/app/util/ApibuilderServiceImportResolver.scala
+++ b/api/app/util/ApibuilderServiceImportResolver.scala
@@ -1,0 +1,27 @@
+package util
+
+import db.{Authorization, VersionsDao}
+import io.apibuilder.api.v0.models.Version
+import io.apibuilder.spec.v0.models.Service
+
+object ApibuilderServiceImportResolver {
+
+  def resolveChildren(service: Service, versionsDao: VersionsDao, auth: Authorization): Map[String, Service] = {
+
+    def resolve(service: Service, acc: Map[String, Service] = Map.empty): Map[String, Service] = {
+      service.imports.foldLeft(acc) { case (acc, imp) =>
+        if (acc.contains(imp.namespace)) {
+          acc
+        } else {
+          versionsDao.findVersion(auth, imp.organization.key, imp.application.key, imp.version) match {
+            case None => acc
+            case Some(v: Version) => resolve(v.service, acc + (imp.namespace -> v.service))
+          }
+        }
+      }
+    }
+    
+    resolve(service)
+  }
+  
+}

--- a/api/test/controllers/CodeSpec.scala
+++ b/api/test/controllers/CodeSpec.scala
@@ -24,7 +24,8 @@ class CodeSpec extends PlaySpec with MockClient with GuiceOneServerPerSuite with
       val generatorWithService = generatorsDao.findAll(db.Authorization.All)
         .headOption.getOrElse(throw new IllegalArgumentException("At least one code generator expected in database"))
 
-      val generatorPort = generatorWithService.service.uri.dropWhile(_ != ':').drop(1).toInt
+      println(generatorWithService.service.uri)
+      val generatorPort = Try(generatorWithService.service.uri.dropWhile(_ != ':').drop(1).toInt).getOrElse(80)
       val generatorKey = generatorWithService.generator.key
 
       val wireMockServer = new WireMockServer(generatorPort)

--- a/api/test/controllers/CodeSpec.scala
+++ b/api/test/controllers/CodeSpec.scala
@@ -1,22 +1,18 @@
 package controllers
 
-import java.io.IOException
-import java.net.{InetSocketAddress, ServerSocket, Socket}
-import java.util.UUID
-import java.util.concurrent.ThreadLocalRandom
-
 import com.github.tomakehurst.wiremock.WireMockServer
-import io.apibuilder.spec.v0.models.Import
-import org.scalatestplus.play.PlaySpec
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import io.apibuilder.spec.v0.{models => spec}
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.matching.RequestPattern
-import io.apibuilder.generator.v0.models.{Invocation, InvocationForm}
 import io.apibuilder.generator.v0.models.json.{jsonReadsApibuilderGeneratorInvocationForm, jsonWritesApibuilderGeneratorInvocation}
+import io.apibuilder.generator.v0.models.{Invocation, InvocationForm}
+import io.apibuilder.spec.v0.models.Import
+import io.apibuilder.spec.v0.{models => spec}
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.Json
+import util.RandomPortFinder
 
-import scala.util.{Random, Try}
+import scala.util.Try
 
 class CodeSpec extends PlaySpec with MockClient with GuiceOneServerPerSuite with db.generators.Helpers {
 
@@ -26,7 +22,7 @@ class CodeSpec extends PlaySpec with MockClient with GuiceOneServerPerSuite with
 
     "post payload containing imported services to generator" in {
 
-      val randomPort = getRandomPort
+      val randomPort = RandomPortFinder.getRandomPort
       val generatorWithService = createGenerator(createGeneratorService(createGeneratorServiceForm(s"http://localhost:$randomPort")))
 
       val generatorKey = generatorWithService.generator.key
@@ -92,29 +88,6 @@ class CodeSpec extends PlaySpec with MockClient with GuiceOneServerPerSuite with
       }
     }
 
-  }
-
-  def getRandomPort: Int = {
-    Stream
-      .continually(randomPort)
-      .dropWhile(port => !checkIfPortIsFree("localhost", port))
-      .head
-  }
-
-  private def randomPort: Int = {
-    10000 + Random.nextInt(55000)
-  }
-
-  private def checkIfPortIsFree(host: String, port: Int): Boolean = {
-    val s = new Socket()
-    try {
-      s.connect(new InetSocketAddress(host, port), 1000)
-      false
-    } catch {
-      case _: IOException => true
-    } finally {
-      s.close()
-    }
   }
 
 }

--- a/api/test/controllers/CodeSpec.scala
+++ b/api/test/controllers/CodeSpec.scala
@@ -1,0 +1,93 @@
+package controllers
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import io.apibuilder.spec.v0.models.Import
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import io.apibuilder.spec.v0.{models => spec}
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.matching.RequestPattern
+import io.apibuilder.generator.v0.models.{Invocation, InvocationForm}
+import io.apibuilder.generator.v0.models.json.{jsonReadsApibuilderGeneratorInvocationForm, jsonWritesApibuilderGeneratorInvocation}
+import play.api.libs.json.Json
+
+import scala.util.Try
+
+class CodeSpec extends PlaySpec with MockClient with GuiceOneServerPerSuite with db.generators.Helpers {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  "Code controller" should {
+
+    "post payload containing imported services to generator" in {
+
+      val generatorWithService = generatorsDao.findAll(db.Authorization.All)
+        .headOption.getOrElse(throw new IllegalArgumentException("At least one code generator expected in database"))
+
+      val generatorPort = generatorWithService.service.uri.dropWhile(!_.isDigit).toInt
+      val generatorKey = generatorWithService.generator.key
+
+      val wireMockServer = new WireMockServer(generatorPort)
+
+      try {
+        wireMockServer.start()
+
+        val mockGeneratorFileList = Seq.empty
+
+        wireMockServer.stubFor(
+          post(urlEqualTo(s"/invocations/$generatorKey"))
+            .willReturn(okJson(
+              Json.toJson(Invocation("", mockGeneratorFileList)).toString()
+            ))
+        )
+
+        val testOrg = createOrganization()
+        // create the first service that will be referenced by an import of an another import
+        val childApp = createApplication(org = testOrg)
+        val childService = createService(childApp)
+        val childVersion = createVersion(application = childApp, service = Some(childService))
+
+        // create the second service that will reference the first one and will be referenced by an import inside main service
+        val intermediateApp = createApplication(org = testOrg)
+        val intermediateService = createService(intermediateApp).copy(
+          imports = Seq(
+            Import(uri = "irrelevant", namespace = childService.namespace, organization = spec.Organization(testOrg.key), application = spec.Application(childApp.key), version = childVersion.version)
+          )
+        )
+        val intermediateVersion = createVersion(application = intermediateApp, service = Some(intermediateService))
+
+        // create the main service that will import the second one
+        val mainApp = createApplication(org = testOrg)
+        val mainService = createService(mainApp).copy(
+          imports = Seq(
+            Import(uri = "anything", namespace = intermediateService.namespace, organization = spec.Organization(testOrg.key), application = spec.Application(intermediateApp.key), version = intermediateVersion.version)
+          )
+        )
+        val mainVersion = createVersion(application = mainApp, service = Some(mainService))
+
+        val resultF = client.code.get(testOrg.key, mainApp.key, mainVersion.version, generatorKey)
+
+        expectStatus(200) {
+          resultF.map(_ => ())
+        }
+
+        val result = await(resultF)
+        result.files mustEqual mockGeneratorFileList
+        result.generator mustEqual generatorWithService
+
+        val wireMockRequestList = wireMockServer.findRequestsMatching(RequestPattern.ANYTHING).getRequests
+        val postRequestBodyString = Try(wireMockRequestList.get(0))
+          .getOrElse(throw new IllegalArgumentException("WireMock test server has not captured any Apibuilder Generator invocation call"))
+          .getBodyAsString
+        val sentInvocationForm = Json.parse(postRequestBodyString).as[InvocationForm]
+
+        sentInvocationForm.importedServices mustEqual Some(Seq(intermediateService, childService))
+
+      } finally {
+        wireMockServer.stop()
+      }
+    }
+
+  }
+
+}

--- a/api/test/controllers/CodeSpec.scala
+++ b/api/test/controllers/CodeSpec.scala
@@ -24,7 +24,7 @@ class CodeSpec extends PlaySpec with MockClient with GuiceOneServerPerSuite with
       val generatorWithService = generatorsDao.findAll(db.Authorization.All)
         .headOption.getOrElse(throw new IllegalArgumentException("At least one code generator expected in database"))
 
-      val generatorPort = generatorWithService.service.uri.dropWhile(!_.isDigit).toInt
+      val generatorPort = generatorWithService.service.uri.dropWhile(_ != ':').drop(1).toInt
       val generatorKey = generatorWithService.generator.key
 
       val wireMockServer = new WireMockServer(generatorPort)

--- a/api/test/util/RandomPortFinder.scala
+++ b/api/test/util/RandomPortFinder.scala
@@ -1,0 +1,31 @@
+package util
+
+import java.io.IOException
+import java.net.{InetSocketAddress, Socket}
+
+object RandomPortFinder {
+
+  def getRandomPort: Int = {
+    Stream
+      .continually(randomPort)
+      .dropWhile(port => !checkIfPortIsFree("localhost", port))
+      .head
+  }
+
+  private def randomPort: Int = {
+    10000 + scala.util.Random.nextInt(55000)
+  }
+
+  private def checkIfPortIsFree(host: String, port: Int): Boolean = {
+    val s = new Socket()
+    try {
+      s.connect(new InetSocketAddress(host, port), 1000)
+      false
+    } catch {
+      case _: IOException => true
+    } finally {
+      s.close()
+    }
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,8 @@ lazy val api = project
       "org.mindrot"       %  "jbcrypt"        % "0.4",
       "com.sendgrid"      %  "sendgrid-java"  % "4.1.2",
       "io.flow"           %% "lib-postgresql-play-play26" % "0.1.68",
-      "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test
+      "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
+      "com.github.tomakehurst" % "wiremock-standalone" % "2.20.0" % Test
     )
   )
 

--- a/generated/app/ApicollectiveApibuilderGeneratorV0Client.scala
+++ b/generated/app/ApicollectiveApibuilderGeneratorV0Client.scala
@@ -77,7 +77,8 @@ package io.apibuilder.generator.v0.models {
   final case class InvocationForm(
     service: io.apibuilder.spec.v0.models.Service,
     attributes: Seq[io.apibuilder.generator.v0.models.Attribute] = Nil,
-    userAgent: _root_.scala.Option[String] = None
+    userAgent: _root_.scala.Option[String] = None,
+    importedServices: _root_.scala.Option[Seq[io.apibuilder.spec.v0.models.Service]] = None
   )
 
   /**
@@ -351,7 +352,8 @@ package io.apibuilder.generator.v0.models {
         service <- (__ \ "service").read[io.apibuilder.spec.v0.models.Service]
         attributes <- (__ \ "attributes").read[Seq[io.apibuilder.generator.v0.models.Attribute]]
         userAgent <- (__ \ "user_agent").readNullable[String]
-      } yield InvocationForm(service, attributes, userAgent)
+        importedServices <- (__ \ "imported_services").readNullable[Seq[io.apibuilder.spec.v0.models.Service]]
+      } yield InvocationForm(service, attributes, userAgent, importedServices)
     }
 
     def jsObjectInvocationForm(obj: io.apibuilder.generator.v0.models.InvocationForm): play.api.libs.json.JsObject = {
@@ -361,6 +363,10 @@ package io.apibuilder.generator.v0.models {
       ) ++ (obj.userAgent match {
         case None => play.api.libs.json.Json.obj()
         case Some(x) => play.api.libs.json.Json.obj("user_agent" -> play.api.libs.json.JsString(x))
+      }) ++
+      (obj.importedServices match {
+        case None => play.api.libs.json.Json.obj()
+        case Some(x) => play.api.libs.json.Json.obj("imported_services" -> play.api.libs.json.Json.toJson(x))
       })
     }
 

--- a/spec/apibuilder-generator.json
+++ b/spec/apibuilder-generator.json
@@ -65,7 +65,8 @@
       "fields": [
         { "name": "service", "type": "io.apibuilder.spec.v0.models.service" },
         { "name": "attributes", "type": "[attribute]", "default": "[]" },
-        { "name": "user_agent", "type": "string", "required": false }
+        { "name": "user_agent", "type": "string", "required": false },
+        { "name": "imported_services", "type": "[io.apibuilder.spec.v0.models.service]", "required": false }
       ]
     },
 


### PR DESCRIPTION
Adds `imported_services` (a list of `Service`) optional field to the Apibuilder code generator invocation.

introduces WireMock library needed to test the API->Generator interaction