### PR TITLE
Fix bug with Swagger import that uses an array in body param

### DIFF
--- a/swagger/src/main/scala/me/apidoc/swagger/translators/Body.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/translators/Body.scala
@@ -1,7 +1,7 @@
 package me.apidoc.swagger.translators
 
 import io.apibuilder.spec.v0.{ models => apidoc }
-import io.swagger.models.{ModelImpl, RefModel}
+import io.swagger.models.{ArrayModel, ModelImpl, RefModel}
 import io.swagger.models.{ parameters => swaggerParams }
 import me.apidoc.swagger.Util
 
@@ -12,6 +12,7 @@ object Body {
     param: swaggerParams.BodyParameter
   ): apidoc.Body = {
     val bodyType = param.getSchema match {
+      case a: ArrayModel => s"[${Field(resolver, param.getName, "", a.getItems).`type`}]"
       case m: ModelImpl => m.getType
       case m: RefModel => resolver.resolveWithError(m).name
       case _ => sys.error("Unsupported body type: " + param.getSchema.getClass)

--- a/swagger/src/test/resources/petstore-external-docs-example-security.json
+++ b/swagger/src/test/resources/petstore-external-docs-example-security.json
@@ -115,10 +115,13 @@
           {
             "name": "pet",
             "in": "body",
-            "description": "Pet to add to the store",
+            "description": "Pets to add to the store",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/newPet"
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/newPet"
+              }
             },
             "x-foo-body": {
               "bar": "body"


### PR DESCRIPTION
Issue: when importing a body parameter with an array:

```
      parameters:
        - name: subscriptions
          in: body
          schema:
            type: array
            items:
              $ref: '#/definitions/Subscription'
```

I was seeing this error: `java.lang.RuntimeException: Unsupported body type: class io.swagger.models.ArrayModel`.

This commit adds a test and resolves the error.