### PR TITLE
Fix migration - corrupt org namespace

### DIFF
--- a/api/app/db/VersionsDao.scala
+++ b/api/app/db/VersionsDao.scala
@@ -362,7 +362,7 @@ class VersionsDao @Inject() (
         // TODO this adds yet another sql call *but* saves us from modifying Version
         //   alternatively use some local VersionWithOrgNamespace model...
         val organizationNamespace = {
-          SQL("select namespace from organizations where guid = {orgGuid}")
+          SQL("select namespace from organizations where guid = {orgGuid}::uuid")
             .on("orgGuid" -> version.organization.guid)
             .executeQuery()
             .as(SqlParser.scalar[String].single)

--- a/api/app/db/VersionsDao.scala
+++ b/api/app/db/VersionsDao.scala
@@ -325,9 +325,6 @@ class VersionsDao @Inject() (
     finalStats
   }
 
-  // TODO #792 - https://github.com/apicollective/apibuilder/issues/792
-  //   - run this locally
-  //   - reproduce this locally
   @tailrec
   private[this] def migrateSingleRun(limit: Int = 5000, offset: Int = 0, stats: MigrationStats = MigrationStats(good = 0, bad = 0)): MigrationStats = {
     var good = 0l
@@ -359,21 +356,16 @@ class VersionsDao @Inject() (
         val versionName = version.version
         val versionGuid = version.guid
 
-        // TODO this adds yet another sql call *but* saves us from modifying Version
-        //   alternatively use some local VersionWithOrgNamespace model...
         val organizationNamespace = {
           SQL("select namespace from organizations where guid = {orgGuid}::uuid")
             .on("orgGuid" -> version.organization.guid)
             .executeQuery()
             .as(SqlParser.scalar[String].single)
         }
-        Logger.error(s"DEV: Migrating for version.service.namespace=${version.service.namespace}, orgKey=${version.organization.key}, orgGuid=${version.organization.guid}")
-
         Logger.info(s"Migrating $orgKey/$applicationKey/$versionName versionGuid[$versionGuid] to latest API Builder spec version[$ServiceVersionNumber]")
 
         val config = ServiceConfiguration(
           orgKey = orgKey,
-//          orgNamespace = version.service.namespace, // TODO why service.namespace -> orgNamespace ???
           orgNamespace = organizationNamespace,
           version = versionName
         )

--- a/api/app/db/VersionsDao.scala
+++ b/api/app/db/VersionsDao.scala
@@ -362,17 +362,18 @@ class VersionsDao @Inject() (
             .executeQuery()
             .as(SqlParser.scalar[String].single)
         }
-        Logger.info(s"Migrating $orgKey/$applicationKey/$versionName versionGuid[$versionGuid] to latest API Builder spec version[$ServiceVersionNumber]")
 
-        val config = ServiceConfiguration(
+        val serviceConfig = ServiceConfiguration(
           orgKey = orgKey,
           orgNamespace = organizationNamespace,
           version = versionName
         )
 
+        Logger.info(s"Migrating $orgKey/$applicationKey/$versionName versionGuid[$versionGuid] to latest API Builder spec version[$ServiceVersionNumber] (with serviceConfig=$serviceConfig)")
+
         try {
           val validator = OriginalValidator(
-            config = config,
+            config = serviceConfig,
             original = version.original.getOrElse {
               sys.error("Missing version")
             },

--- a/api/app/db/VersionsDao.scala
+++ b/api/app/db/VersionsDao.scala
@@ -369,7 +369,7 @@ class VersionsDao @Inject() (
         }
         Logger.error(s"DEV: Migrating for version.service.namespace=${version.service.namespace}, orgKey=${version.organization.key}, orgGuid=${version.organization.guid}")
 
-        Logger.info(s"Migrating $orgKey/$applicationKey/$versionName versionGuid[versionGuid] to latest API Builder spec version[$ServiceVersionNumber]")
+        Logger.info(s"Migrating $orgKey/$applicationKey/$versionName versionGuid[$versionGuid] to latest API Builder spec version[$ServiceVersionNumber]")
 
         val config = ServiceConfiguration(
           orgKey = orgKey,

--- a/api/app/db/VersionsDao.scala
+++ b/api/app/db/VersionsDao.scala
@@ -325,6 +325,9 @@ class VersionsDao @Inject() (
     finalStats
   }
 
+  // TODO #792 - https://github.com/apicollective/apibuilder/issues/792
+  //   - run this locally
+  //   - reproduce this locally
   @tailrec
   private[this] def migrateSingleRun(limit: Int = 5000, offset: Int = 0, stats: MigrationStats = MigrationStats(good = 0, bad = 0)): MigrationStats = {
     var good = 0l
@@ -356,11 +359,22 @@ class VersionsDao @Inject() (
         val versionName = version.version
         val versionGuid = version.guid
 
+        // TODO this adds yet another sql call *but* saves us from modifying Version
+        //   alternatively use some local VersionWithOrgNamespace model...
+        val organizationNamespace = {
+          SQL("select namespace from organizations where guid = {orgGuid}")
+            .on("orgGuid" -> version.organization.guid)
+            .executeQuery()
+            .as(SqlParser.scalar[String].single)
+        }
+        Logger.error(s"DEV: Migrating for version.service.namespace=${version.service.namespace}, orgKey=${version.organization.key}, orgGuid=${version.organization.guid}")
+
         Logger.info(s"Migrating $orgKey/$applicationKey/$versionName versionGuid[versionGuid] to latest API Builder spec version[$ServiceVersionNumber]")
 
         val config = ServiceConfiguration(
           orgKey = orgKey,
-          orgNamespace = version.service.namespace,
+//          orgNamespace = version.service.namespace, // TODO why service.namespace -> orgNamespace ???
+          orgNamespace = organizationNamespace,
           version = versionName
         )
 

--- a/lib/src/test/scala/ServiceConfigurationSpec.scala
+++ b/lib/src/test/scala/ServiceConfigurationSpec.scala
@@ -37,4 +37,5 @@ class ServiceConfigurationSpec extends FunSpec with Matchers {
     val config = createServiceConfiguration("io.apibuilder")
     config.applicationNamespace("mercury-3pl") should be("io.apibuilder.mercury3pl.v1")
   }
+
 }

--- a/lib/src/test/scala/ServiceConfigurationSpec.scala
+++ b/lib/src/test/scala/ServiceConfigurationSpec.scala
@@ -38,4 +38,10 @@ class ServiceConfigurationSpec extends FunSpec with Matchers {
     config.applicationNamespace("mercury-3pl") should be("io.apibuilder.mercury3pl.v1")
   }
 
+  it("dev - reproduce apibuilder/issues/792") {
+    // TODO #792 - the below example demonstrates that orgNamespace is assumed to be appFullNamespace 😱😱😱 => hence the bug
+    val appFullNamespace = "me.apidoc.my.api.v1"
+    createServiceConfiguration(orgNamespace = appFullNamespace).applicationNamespace("my-api") should be("me.apidoc.my.api.v1.my.api.v1") // 💥
+  }
+
 }

--- a/lib/src/test/scala/ServiceConfigurationSpec.scala
+++ b/lib/src/test/scala/ServiceConfigurationSpec.scala
@@ -37,11 +37,4 @@ class ServiceConfigurationSpec extends FunSpec with Matchers {
     val config = createServiceConfiguration("io.apibuilder")
     config.applicationNamespace("mercury-3pl") should be("io.apibuilder.mercury3pl.v1")
   }
-
-  it("dev - reproduce apibuilder/issues/792") {
-    // TODO #792 - the below example demonstrates that orgNamespace is assumed to be appFullNamespace 😱😱😱 => hence the bug
-    val appFullNamespace = "me.apidoc.my.api.v1"
-    createServiceConfiguration(orgNamespace = appFullNamespace).applicationNamespace("my-api") should be("me.apidoc.my.api.v1.my.api.v1") // 💥
-  }
-
 }


### PR DESCRIPTION
Fixes #792.

Currently migration overwrites with `org namespace` with `service namespace`.
Hence  
`org namespace=io.github.mkows` and application `playground-api`, the result is not `io.github.mkows.playground.api.v0` (as expected) but `io.github.mkows.playground.api.v0.playground.api.v0`.

This PR introduces `1 + N` db calls (up from `1`) to fetch organization namespace -- this is to not modify `Version` model (an alternative would be to have a dedicated `Version + org namespace` model).

h3. Initial description (archive)

Unit test demonstrates the issue.
Proposal of the fix -- not tested at all yet -- just code draft.

```
records.foreach { version =>
        val orgKey = version.organization.key
        val applicationKey = version.application.key
        val versionName = version.version
        val versionGuid = version.guid
        // ...
        Logger.error(s"DEV: Migrating for version.service.namespace=${version.service.namespace}, orgKey=${version.organization.key}, orgGuid=${version.organization.guid}")

        Logger.info(s"Migrating $orgKey/$applicationKey/$versionName versionGuid[$versionGuid] to latest API Builder spec version[$ServiceVersionNumber]")

        // current PROD code:
        val config = ServiceConfiguration(
          orgKey = orgKey,
          orgNamespace = version.service.namespace,
          version = versionName
        )

```

prints
```
DEV: Migrating for version.service.namespace=io.github.mkows.playground.api.v0, orgKey=michal, orgGuid=ceeea5e9-d2f8-4be2-967e-5e9a2fe6b260
``` 
which demonstrates how currently on PROD `orgNamespace` gets overwritten with _full_ `version.service.namespace` while it should be unaltered (i.e. `io.github.mkows`)