### PR TITLE
Defaults unknown Swagger string formats to map into an ApiBuilder str…

### DIFF
--- a/swagger/src/main/scala/me/apidoc/swagger/SchemaType.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/SchemaType.scala
@@ -31,7 +31,19 @@ object SchemaType {
     swaggerType: String,
     format: Option[String]
   ): Option[String] = {
-    all.find(schemaType => schemaType.swaggerFormat == format && schemaType.swaggerType == swaggerType).map(_.apidoc)
+    all
+      .find(schemaType => schemaType.swaggerFormat == format && schemaType.swaggerType == swaggerType)
+      .map(_.apidoc)
+      .orElse {
+        swaggerType match {
+          /*
+           Format is an open-valued property (can have any value, such as "email", "html", etc). In the case of type string
+           and we want to always map it to an ApiBuilder string for all the case not explicitly mapped (e.g. date-time, uuid).
+           */
+          case "string" => Some("string")
+          case _ => None
+        }
+      }
   }
 
   def fromSwaggerWithError(

--- a/swagger/src/test/resources/petstore-enums.json
+++ b/swagger/src/test/resources/petstore-enums.json
@@ -136,12 +136,12 @@
         "name"
       ],
       "properties": {
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
         "name": {
           "type": "string"
+        },
+        "email_address": {
+          "type": "string",
+          "format": "email"
         },
         "tag": {
           "type": "string",
@@ -149,12 +149,20 @@
             "bar": "field"
           }
         },
+        "additional_info": {
+          "type": "object"
+        },
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
         "status": {
           "type": "string",
           "enum": ["available", "pending", "sold"]
         },
-        "additional_info": {
-          "type": "object"
+        "html_description": {
+          "type": "string",
+          "format": "html"
         }
       },
       "x-foo-model": {

--- a/swagger/src/test/scala/me/apidoc/swagger/SwaggerServiceValidatorSpec.scala
+++ b/swagger/src/test/scala/me/apidoc/swagger/SwaggerServiceValidatorSpec.scala
@@ -88,6 +88,11 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                       required = true
                     ),
                     Field(
+                      name = "email_address",
+                      `type` = "string",
+                      required = false
+                    ),
+                    Field(
                       name = "tag",
                       `type` = "string",
                       required = false,
@@ -109,6 +114,11 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                     Field(
                       name = "status",
                       `type` = "PetStatus",
+                      required = false
+                    ),
+                    Field(
+                      name = "html_description",
+                      `type` = "string",
                       required = false
                     )
                   ),


### PR DESCRIPTION
…ing type. Fixes #711.

As per https://swagger.io/specification/#dataTypeFormat, the format property is an open string-valued property, and can have any value. In fact there are real examples of Swagger spec with formats like `email`, `html`.
With this change we always map these cases into a string type and keep the custom mapping for formats like `uuid`, `date`, `date-time`.