### PR TITLE
Allow names that start with an underscore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,5 @@ jobs:
       run: java -version
     - name: Build
       run: |
-        docker run -d -p 127.0.0.1:7659:5432 flowcommerce/apibuilder-postgresql:latest
+        docker run -d -p 127.0.0.1:5432:5432 flowcommerce/apibuilder-postgresql:latest
         sbt ++${{ matrix.scala }} clean coverage test coverageReport

--- a/core/src/test/scala/core/ServiceValidatorSpec.scala
+++ b/core/src/test/scala/core/ServiceValidatorSpec.scala
@@ -74,7 +74,7 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     }
     """
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors().mkString should be("Model[user] field name[_!@#] is invalid: Name can only contain a-z, A-Z, 0-9, - and _ characters and Name must start with a letter")
+    validator.errors().mkString should be("Model[user] field name[_!@#] is invalid: Name can only contain a-z, A-Z, 0-9, - and _ characters")
   }
 
   it("model with duplicate field names") {

--- a/lib/src/main/scala/Text.scala
+++ b/lib/src/main/scala/Text.scala
@@ -18,7 +18,7 @@ object Text {
                               Seq("Name can only contain a-z, A-Z, 0-9, - and _ characters")
                             }
 
-    val startsWithLetterError = if (startsWithLetter(name)) {
+    val startsWithLetterError = if (startsWithLetter(name) || (startsWithUnderscore(name) && name.length > 1)) {
                                   Seq.empty
                                 } else if (name.isEmpty) {
                                   Seq("Name cannot be blank")
@@ -46,6 +46,15 @@ object Text {
       case _ => false
     }
     result
+  }
+
+  private[this] val StartsWithUnderscoreRx = "^_.*".r
+
+  def startsWithUnderscore(value: String): Boolean = {
+    value match {
+      case StartsWithUnderscoreRx() => true
+      case _ => false
+    }
   }
 
   private[this] val Ellipsis = "..."

--- a/lib/src/test/scala/TextSpec.scala
+++ b/lib/src/test/scala/TextSpec.scala
@@ -31,7 +31,7 @@ class TextSpec extends FunSpec with Matchers {
 
   it("isValidName") {
     Text.isValidName("") should be(false)
-    Text.isValidName("_vendor") should be(false)
+    Text.isValidName("_vendor") should be(true)
     Text.isValidName("1vendor") should be(false)
     Text.isValidName("1") should be(false)
     Text.isValidName("_") should be(false)
@@ -43,7 +43,7 @@ class TextSpec extends FunSpec with Matchers {
 
   it("validateName") {
     Text.validateName("") should be(Seq("Name cannot be blank"))
-    Text.validateName("_vendor") should be(Seq("Name must start with a letter"))
+    Text.validateName("_vendor") should be(Seq.empty)
     Text.validateName("1vendor") should be(Seq("Name must start with a letter"))
     Text.validateName("1") should be(Seq("Name must start with a letter"))
     Text.validateName("_") should be(Seq("Name must start with a letter"))


### PR DESCRIPTION
I'm modelling [https://readme.com/](https://readme.com/)'s API. Their API responses return object IDs in the `_id` field. Apibuilder currently rejects this.