### PR TITLE
Enforce a unique discriminator key and value per model across union types

### DIFF
--- a/core/src/main/scala/core/builder/ServiceSpecValidator.scala
+++ b/core/src/main/scala/core/builder/ServiceSpecValidator.scala
@@ -337,10 +337,10 @@ case class ServiceSpecValidator(
     }
   }
 
-  private[this] def  getDiscriminatorValue(unionType: UnionType): String =
+  private[this] def getDiscriminatorValue(unionType: UnionType): String =
     unionType.discriminatorValue.getOrElse(unionType.`type`)
 
-  private[this] def  getDiscriminatorKey(union: Union): String =
+  private[this] def getDiscriminatorKey(union: Union): String =
     union.discriminator.getOrElse("discriminator")
 
   private[this] def validateUnionTypeDiscriminatorKeyValuesAreUniquePerModel(): Seq[String] =

--- a/core/src/test/scala/core/UnionTypeDiscriminatorValueSpec.scala
+++ b/core/src/test/scala/core/UnionTypeDiscriminatorValueSpec.scala
@@ -243,29 +243,29 @@ class UnionTypeDiscriminatorValueSpec extends FunSpec with Matchers {
   }
 
   it("union type cannot share the same models if their discriminator key is NOT unique") {
-    val validator = TestHelper.serviceValidatorFromApiJson(
-      baseJson.format(
-        """
-          |"user": {
-          |  "discriminator": "key",
-          |  "types": [
-          |    { "type": "registered_user", "discriminator_value": "registered" },
-          |    { "type": "guest_user" }
-          |  ]
-          |},
-          |
-          |"other_user_union": {
-          |  "types": [
-          |    { "type": "registered_user", "discriminator_value": "registered" }
-          |  ]
-          |}
-        """.stripMargin
-      )
-    )
-    validator.errors should be (Seq(
-      "Model[registered_user] used in unions[other_user_union, user] cannot use more than one discriminator key. " +
-        "Found distinct discriminator keys[discriminator, key]"
-    ))
+ val validator = TestHelper.serviceValidatorFromApiJson(
+   baseJson.format(
+     """
+       |"user": {
+       |  "discriminator": "key",
+       |  "types": [
+       |    { "type": "registered_user", "discriminator_value": "registered" },
+       |    { "type": "guest_user" }
+       |  ]
+       |},
+       |
+       |"other_user_union": {
+       |  "types": [
+       |    { "type": "registered_user", "discriminator_value": "registered" }
+       |  ]
+       |}
+     """.stripMargin
+   )
+ )
+ validator.errors should be (Seq(
+   "Model[registered_user] used in unions[other_user_union, user] cannot use more than one discriminator key. " +
+     "Found distinct discriminator keys[discriminator, key]"
+ ))
   }
 
 }

--- a/core/src/test/scala/core/UnionTypeDiscriminatorValueSpec.scala
+++ b/core/src/test/scala/core/UnionTypeDiscriminatorValueSpec.scala
@@ -207,11 +207,11 @@ class UnionTypeDiscriminatorValueSpec extends FunSpec with Matchers {
     )
     validator.errors should be (Seq(
       "Model[registered_user] used in unions[other_user_union, user] cannot use more than one discriminator value. " +
-        "Found distinct discriminator values[other_registered, registered]"
+        "Found distinct discriminator values[other_registered, registered]."
     ))
   }
 
-  it("union type can share the same models if their discriminator key is unique") {
+  it("union type can share the same models if their discriminator name is unique") {
     val validator = TestHelper.serviceValidatorFromApiJson(
       baseJson.format(
         """
@@ -242,30 +242,57 @@ class UnionTypeDiscriminatorValueSpec extends FunSpec with Matchers {
     sortedUnions(1).types.flatMap(_.discriminatorValue) shouldBe Seq("registered", "guest_user")
   }
 
-  it("union type cannot share the same models if their discriminator key is NOT unique") {
- val validator = TestHelper.serviceValidatorFromApiJson(
-   baseJson.format(
-     """
-       |"user": {
-       |  "discriminator": "key",
-       |  "types": [
-       |    { "type": "registered_user", "discriminator_value": "registered" },
-       |    { "type": "guest_user" }
-       |  ]
-       |},
-       |
-       |"other_user_union": {
-       |  "types": [
-       |    { "type": "registered_user", "discriminator_value": "registered" }
-       |  ]
-       |}
+  it("union type cannot share the same models if their discriminator name is NOT unique") {
+    val validator = TestHelper.serviceValidatorFromApiJson(
+      baseJson.format(
+        """
+          |"user": {
+          |  "discriminator": "key",
+          |  "types": [
+          |    { "type": "registered_user", "discriminator_value": "registered" },
+          |    { "type": "guest_user" }
+          |  ]
+          |},
+          |
+          |"other_user_union": {
+          |  "discriminator": "other_key",
+          |  "types": [
+          |    { "type": "registered_user", "discriminator_value": "registered" }
+          |  ]
+          |}
      """.stripMargin
-   )
- )
- validator.errors should be (Seq(
-   "Model[registered_user] used in unions[other_user_union, user] cannot use more than one discriminator key. " +
-     "Found distinct discriminator keys[discriminator, key]"
- ))
+      )
+    )
+    validator.errors should be (Seq(
+      "Model[registered_user] used in unions[other_user_union, user] cannot use more than one discriminator name. " +
+        "Found distinct discriminator names[other_key, key]."
+    ))
+  }
+
+  it("union type cannot share the same models if their discriminator key is NOT define for all") {
+    val validator = TestHelper.serviceValidatorFromApiJson(
+      baseJson.format(
+        """
+          |"user": {
+          |  "discriminator": "key",
+          |  "types": [
+          |    { "type": "registered_user", "discriminator_value": "registered" },
+          |    { "type": "guest_user" }
+          |  ]
+          |},
+          |
+          |"other_user_union": {
+          |  "types": [
+          |    { "type": "registered_user", "discriminator_value": "registered" }
+          |  ]
+          |}
+     """.stripMargin
+      )
+    )
+    validator.errors should be (Seq(
+      "Model[registered_user] used in unions[other_user_union, user] cannot use more than one discriminator name. " +
+        "All unions should define the same discriminator name, or not define one at all."
+    ))
   }
 
 }


### PR DESCRIPTION
Resolves https://github.com/apicollective/apibuilder/issues/818

In addition, enforce a unique discriminator key per model across union type.