### PR TITLE
Enable union and interface to share names

### DIFF
--- a/core/src/main/scala/core/builder/ServiceSpecValidator.scala
+++ b/core/src/main/scala/core/builder/ServiceSpecValidator.scala
@@ -591,11 +591,12 @@ case class ServiceSpecValidator(
     * always indicate if a type referenced a model, union, or enum.
     */
   private def validateTypeNamesAreUnique(): Seq[String] = {
+    val unionNames = service.unions.map(_.name)
     val validators: Seq[TypesUniqueValidator] = Seq(
-      TypesUniqueValidator("an interface", service.interfaces.map(_.name)),
+      TypesUniqueValidator("an interface", service.interfaces.map(_.name).filterNot(unionNames.contains)),
       TypesUniqueValidator("a model", service.models.map(_.name)),
       TypesUniqueValidator("an enum", service.enums.map(_.name)),
-      TypesUniqueValidator("a union", service.unions.map(_.name)),
+      TypesUniqueValidator("a union", unionNames),
     )
 
     validators.flatMap(_.all.toSeq)


### PR DESCRIPTION
- in code generation, distinction between union and interface is minimal if any
  - enable use of the same name to define the union and interface. Code generation
    can then define the interface on the union type directly and avoid humans
    needing to create two names for a single concept