### PR TITLE
Support $schema field on api.json

### DIFF
--- a/core/src/main/scala/core/builder/api_json/ApiJsonServiceValidator.scala
+++ b/core/src/main/scala/core/builder/api_json/ApiJsonServiceValidator.scala
@@ -129,8 +129,8 @@ case class ApiJsonServiceValidator(
   private def validateStructure(): Seq[String] = {
     JsonUtil.validate(
       internalService.get.json,
-      strings = Seq("name", "$schema"),
-      optionalStrings = Seq("base_url", "description", "namespace"),
+      strings = Seq("name"),
+      optionalStrings = Seq("base_url", "description", "namespace", "$schema"),
       optionalArraysOfObjects = Seq("imports", "headers", "attributes"),
       optionalObjects = Seq("apidoc", "info", "enums", "interfaces", "models", "unions", "resources", "annotations")
     )

--- a/core/src/main/scala/core/builder/api_json/ApiJsonServiceValidator.scala
+++ b/core/src/main/scala/core/builder/api_json/ApiJsonServiceValidator.scala
@@ -129,7 +129,7 @@ case class ApiJsonServiceValidator(
   private def validateStructure(): Seq[String] = {
     JsonUtil.validate(
       internalService.get.json,
-      strings = Seq("name"),
+      strings = Seq("name", "$schema"),
       optionalStrings = Seq("base_url", "description", "namespace"),
       optionalArraysOfObjects = Seq("imports", "headers", "attributes"),
       optionalObjects = Seq("apidoc", "info", "enums", "interfaces", "models", "unions", "resources", "annotations")


### PR DESCRIPTION
By adding `"$schema": "https://json.schemastore.org/apibuilder.json"` to our api.json files, we get autocompletion OOTB in VSCode, and probably better support for other editors

Related to #835 