### PR TITLE
Only send 1 auth header to api

### DIFF
--- a/app/app/lib/ApiClientProvider.scala
+++ b/app/app/lib/ApiClientProvider.scala
@@ -27,7 +27,7 @@ class ApiClientProvider @Inject() (
     new io.apibuilder.api.v0.Client(
       wSClient,
       baseUrl = baseUrl,
-      auth = Some(apiAuth),
+      auth = if (sessionId.isEmpty) Some(apiAuth) else None,
       defaultHeaders = sessionId.map { id =>
         "Authorization" -> ("Session " + URLEncoder.encode(id, "UTF-8"))
       }.toSeq


### PR DESCRIPTION
Right now we are sending 2 Authorization headers if we have a session ID:

in ECS:
```
Authorization: Session A51...
authorization: Basic UGV5Un...
```

in k8s (my guess is istio rewriting the headers):
```
authorization: Session A51...,Basic UGV5Un...
```

so the auth header parsing is failing in k8s