### PR TITLE
Validate discriminator value across nested union types

### DIFF
--- a/core/src/test/scala/core/NestedUnionsSpec.scala
+++ b/core/src/test/scala/core/NestedUnionsSpec.scala
@@ -41,4 +41,49 @@ class NestedUnionsSpec extends FunSpec with Matchers with helpers.ApiJsonHelpers
         "Union[party] discriminator value[user] appears more than once"
       )
   }
+
+  it("share a common discriminator") {
+    def setup(
+      userDiscriminatorName: Option[String],
+      guestDiscriminatorName: Option[String],
+      partyDiscriminatorName: Option[String],
+    ) = {
+      val service = makeApiJson(
+        models = Map(
+          "user" -> makeModelWithField(),
+          "guest" -> makeModelWithField(),
+        ),
+        unions = Map(
+          "abstract_user" -> makeUnion(
+            discriminator = userDiscriminatorName,
+            types = Seq(makeUnionType("user"))
+          ),
+          "abstract_guest" -> makeUnion(
+            discriminator = guestDiscriminatorName,
+            types = Seq(makeUnionType("guest")),
+          ),
+          "party" -> makeUnion(
+            discriminator = partyDiscriminatorName,
+            types = Seq(
+              makeUnionType("abstract_user"),
+              makeUnionType("abstract_guest"),
+            )
+          )
+        )
+      )
+      TestHelper.serviceValidator(service).errors()
+    }
+
+    setup(None, None, None) shouldBe Nil
+    setup(Some("discriminator"), Some("discriminator"), Some("discriminator")) shouldBe Nil
+    setup(Some("discriminator"), None, None) shouldBe Seq(
+      "Union[party] does not specify a discriminator yet one of the types does. Either add the same discriminator to this union or remove from the member types"
+    )
+    setup(None, None, Some("discriminator")) shouldBe Seq(
+      "Union[party] specifies a discriminator named 'discriminator'. All member types must also specify this same discriminator"
+    )
+    setup(Some("foo"), Some("discriminator"), Some("discriminator")) shouldBe Seq(
+      "Union[party] specifies a discriminator named 'discriminator'. All member types must also specify this same discriminator"
+    )
+  }
 }


### PR DESCRIPTION
 - If a union type contains other union types, verify that one of the following is true
   - all the union types define NO discriminator
   - all the union types define a discriminator with the same name