### PR TITLE
Add batch versions latest API endpoint

### DIFF
--- a/api/app/controllers/BatchVersionsLatest.scala
+++ b/api/app/controllers/BatchVersionsLatest.scala
@@ -1,0 +1,26 @@
+package controllers
+
+import cats.data.Validated.{Invalid, Valid}
+import io.apibuilder.api.v0.models.BatchVersionsLatestForm
+import io.apibuilder.api.v0.models.json.*
+import lib.Validation
+import play.api.libs.json.Json
+import play.api.mvc.Action
+import services.BatchVersionsLatestService
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class BatchVersionsLatest @Inject() (
+  override val apiBuilderControllerComponents: ApiBuilderControllerComponents,
+  service: BatchVersionsLatestService,
+) extends ApiBuilderController {
+
+  def post(orgKey: String): Action[BatchVersionsLatestForm] = Anonymous(parse.json[BatchVersionsLatestForm]) { request =>
+    service.process(orgKey, request.body) match {
+      case Valid(result) => Ok(Json.toJson(result))
+      case Invalid(errors) => Conflict(Json.toJson(Validation.errors(errors)))
+    }
+  }
+
+}

--- a/api/app/db/InternalVersionsDao.scala
+++ b/api/app/db/InternalVersionsDao.scala
@@ -209,6 +209,44 @@ class InternalVersionsDao @Inject()(
     }).map(InternalVersion(_))
   }
 
+  /**
+   * Efficient single-query lookup of the latest version string for multiple applications
+   * within an organization. Returns a map of application_key -> latest_version.
+   */
+  def findLatestVersions(
+    orgKey: String,
+    applicationKeys: Seq[String],
+  ): Map[String, String] = {
+    if (applicationKeys.isEmpty) {
+      Map.empty
+    } else {
+      val keyParams = applicationKeys.zipWithIndex.map { case (_, i) => s"{app_key_$i}" }.mkString(", ")
+      val namedParams = applicationKeys.zipWithIndex.map { case (key, i) =>
+        NamedParameter(s"app_key_$i", key)
+      }
+
+      dao.db.withConnection { implicit c =>
+        SQL(
+          s"""select distinct on (a.key) a.key as app_key, versions.version
+              |  from versions
+              |  join applications a on a.guid = versions.application_guid
+              |  join organizations o on o.guid = a.organization_guid
+              | where o.key = {org_key}
+              |   and a.key in ($keyParams)
+              |   and versions.deleted_at is null
+              |   and a.deleted_at is null
+              |   and o.deleted_at is null
+              |   and $HasServiceJsonClause
+              | order by a.key, versions.version_sort_key desc""".stripMargin
+        ).on(
+          (Seq(NamedParameter("org_key", orgKey)) ++ namedParams)*
+        ).as(
+          (SqlParser.str("app_key") ~ SqlParser.str("version")).map { case key ~ version => key -> version }.*
+        ).toMap
+      }
+    }
+  }
+
   // Efficient query to fetch all versions of a given application
   def findAllVersions(
     authorization: Authorization,

--- a/api/app/services/BatchVersionsLatestService.scala
+++ b/api/app/services/BatchVersionsLatestService.scala
@@ -1,0 +1,35 @@
+package services
+
+import cats.data.ValidatedNec
+import cats.implicits.*
+import db.InternalVersionsDao
+import io.apibuilder.api.v0.models.{BatchVersionLatest, BatchVersionsLatest, BatchVersionsLatestForm}
+
+import javax.inject.Inject
+
+class BatchVersionsLatestService @Inject() (
+  versionsDao: InternalVersionsDao,
+) {
+
+  private val MaxApplicationKeys = 500
+
+  def process(
+    orgKey: String,
+    form: BatchVersionsLatestForm,
+  ): ValidatedNec[String, BatchVersionsLatest] = {
+    if (form.applicationKeys.length > MaxApplicationKeys) {
+      s"Maximum of $MaxApplicationKeys application keys allowed, but ${form.applicationKeys.length} were provided".invalidNec
+    } else {
+      val latestVersions = versionsDao.findLatestVersions(orgKey, form.applicationKeys)
+
+      BatchVersionsLatest(
+        applications = form.applicationKeys.map { key =>
+          BatchVersionLatest(
+            applicationKey = key,
+            latestVersion = latestVersions.get(key),
+          )
+        },
+      ).validNec
+    }
+  }
+}

--- a/api/conf/routes
+++ b/api/conf/routes
@@ -66,6 +66,7 @@ PUT        /:orgKey/:applicationKey                                  controllers
 DELETE     /:orgKey/:applicationKey                                  controllers.Applications.deleteByApplicationKey(orgKey: String, applicationKey: String)
 POST       /:orgKey/:applicationKey/move                             controllers.Applications.postMoveByApplicationKey(orgKey: String, applicationKey: String)
 POST       /:orgKey/batch/download/applications                      controllers.BatchDownloadApplications.post(orgKey: String)
+POST       /:orgKey/batch/versions/latest                             controllers.BatchVersionsLatest.post(orgKey: String)
 POST       /:orgKey/:applicationKey/:version/form                    controllers.Code.postForm(orgKey: String, applicationKey: String, version: String)
 GET        /:orgKey/:applicationKey/:version/:generatorKey           controllers.Code.getByGeneratorKey(orgKey: String, applicationKey: String, version: String, generatorKey: String)
 POST       /:orgKey/:applicationKey/:version/:generatorKey           controllers.Code.postByGeneratorKey(orgKey: String, applicationKey: String, version: String, generatorKey: String)

--- a/api/test/controllers/BatchVersionsLatestSpec.scala
+++ b/api/test/controllers/BatchVersionsLatestSpec.scala
@@ -1,0 +1,77 @@
+package controllers
+
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import org.scalatestplus.play.PlaySpec
+import io.apibuilder.api.v0.models.BatchVersionsLatestForm
+
+class BatchVersionsLatestSpec extends PlaySpec with MockClient with GuiceOneServerPerSuite {
+
+  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  private lazy val org = createOrganization()
+  private lazy val version = createVersion(createApplication(org))
+
+  "post" must {
+    "returns latest version for existing application" in {
+      val result = await {
+        client.batchVersionsLatest.post(
+          org.key,
+          BatchVersionsLatestForm(applicationKeys = Seq(version.application.key))
+        )
+      }
+      result.applications.size must equal(1)
+      result.applications.head.applicationKey must equal(version.application.key)
+      result.applications.head.latestVersion must equal(Some(version.version))
+    }
+
+    "returns no version for non-existent application" in {
+      val result = await {
+        client.batchVersionsLatest.post(
+          org.key,
+          BatchVersionsLatestForm(applicationKeys = Seq(randomString()))
+        )
+      }
+      result.applications.size must equal(1)
+      result.applications.head.latestVersion must equal(None)
+    }
+
+    "handles multiple applications" in {
+      val version2 = createVersion(createApplication(org))
+      val result = await {
+        client.batchVersionsLatest.post(
+          org.key,
+          BatchVersionsLatestForm(applicationKeys = Seq(version.application.key, version2.application.key))
+        )
+      }
+      result.applications.size must equal(2)
+      result.applications.map(_.applicationKey) must equal(Seq(version.application.key, version2.application.key))
+      result.applications.foreach { app =>
+        app.latestVersion mustBe defined
+      }
+    }
+
+    "handles mix of existing and non-existent applications" in {
+      val nonExistent = randomString()
+      val result = await {
+        client.batchVersionsLatest.post(
+          org.key,
+          BatchVersionsLatestForm(applicationKeys = Seq(version.application.key, nonExistent))
+        )
+      }
+      result.applications.size must equal(2)
+      result.applications.find(_.applicationKey == version.application.key).get.latestVersion must equal(Some(version.version))
+      result.applications.find(_.applicationKey == nonExistent).get.latestVersion must equal(None)
+    }
+
+    "handles empty list" in {
+      val result = await {
+        client.batchVersionsLatest.post(
+          org.key,
+          BatchVersionsLatestForm(applicationKeys = Nil)
+        )
+      }
+      result.applications must equal(Nil)
+    }
+  }
+
+}

--- a/generated/app/ApicollectiveApibuilderApiV0Client.scala
+++ b/generated/app/ApicollectiveApibuilderApiV0Client.scala
@@ -208,6 +208,28 @@ package io.apibuilder.api.v0.models {
   )
 
   /**
+   * The latest version for a single application, if any versions exist.
+   */
+  final case class BatchVersionLatest(
+    applicationKey: String,
+    latestVersion: _root_.scala.Option[String] = None
+  )
+
+  /**
+   * Response containing the latest version for each requested application.
+   */
+  final case class BatchVersionsLatest(
+    applications: Seq[io.apibuilder.api.v0.models.BatchVersionLatest]
+  )
+
+  /**
+   * Form to request the latest version for multiple applications in a single API call.
+   */
+  final case class BatchVersionsLatestForm(
+    applicationKeys: Seq[String]
+  )
+
+  /**
    * Represents a single change from one version of a service to another
    *
    * @param changedAt Records the timestamp of when the actual change occurred (vs. when we created
@@ -1425,6 +1447,57 @@ package io.apibuilder.api.v0.models {
       }
     }
 
+    implicit def jsonReadsApibuilderApiBatchVersionLatest: play.api.libs.json.Reads[io.apibuilder.api.v0.models.BatchVersionLatest] = {
+      for {
+        applicationKey <- (__ \ "application_key").read[String]
+        latestVersion <- (__ \ "latest_version").readNullable[String]
+      } yield BatchVersionLatest(applicationKey = applicationKey, latestVersion = latestVersion)
+    }
+
+    def jsObjectBatchVersionLatest(obj: io.apibuilder.api.v0.models.BatchVersionLatest): play.api.libs.json.JsObject = {
+      play.api.libs.json.Json.obj(
+        "application_key" -> play.api.libs.json.JsString(obj.applicationKey)
+      ) ++ obj.latestVersion.fold(play.api.libs.json.Json.obj()) { v => play.api.libs.json.Json.obj("latest_version" -> play.api.libs.json.JsString(v)) }
+    }
+
+    implicit def jsonWritesApibuilderApiBatchVersionLatest: play.api.libs.json.Writes[BatchVersionLatest] = {
+      (obj: io.apibuilder.api.v0.models.BatchVersionLatest) => {
+        io.apibuilder.api.v0.models.json.jsObjectBatchVersionLatest(obj)
+      }
+    }
+
+    implicit def jsonReadsApibuilderApiBatchVersionsLatest: play.api.libs.json.Reads[io.apibuilder.api.v0.models.BatchVersionsLatest] = {
+      (__ \ "applications").read[Seq[io.apibuilder.api.v0.models.BatchVersionLatest]].map { x => BatchVersionsLatest(applications = x) }
+    }
+
+    def jsObjectBatchVersionsLatest(obj: io.apibuilder.api.v0.models.BatchVersionsLatest): play.api.libs.json.JsObject = {
+      play.api.libs.json.Json.obj(
+        "applications" -> play.api.libs.json.Json.toJson(obj.applications)
+      )
+    }
+
+    implicit def jsonWritesApibuilderApiBatchVersionsLatest: play.api.libs.json.Writes[BatchVersionsLatest] = {
+      (obj: io.apibuilder.api.v0.models.BatchVersionsLatest) => {
+        io.apibuilder.api.v0.models.json.jsObjectBatchVersionsLatest(obj)
+      }
+    }
+
+    implicit def jsonReadsApibuilderApiBatchVersionsLatestForm: play.api.libs.json.Reads[io.apibuilder.api.v0.models.BatchVersionsLatestForm] = {
+      (__ \ "application_keys").read[Seq[String]].map { x => BatchVersionsLatestForm(applicationKeys = x) }
+    }
+
+    def jsObjectBatchVersionsLatestForm(obj: io.apibuilder.api.v0.models.BatchVersionsLatestForm): play.api.libs.json.JsObject = {
+      play.api.libs.json.Json.obj(
+        "application_keys" -> play.api.libs.json.Json.toJson(obj.applicationKeys)
+      )
+    }
+
+    implicit def jsonWritesApibuilderApiBatchVersionsLatestForm: play.api.libs.json.Writes[BatchVersionsLatestForm] = {
+      (obj: io.apibuilder.api.v0.models.BatchVersionsLatestForm) => {
+        io.apibuilder.api.v0.models.json.jsObjectBatchVersionsLatestForm(obj)
+      }
+    }
+
     implicit def jsonReadsApibuilderApiChange: play.api.libs.json.Reads[io.apibuilder.api.v0.models.Change] = {
       for {
         guid <- (__ \ "guid").read[_root_.java.util.UUID]
@@ -2548,6 +2621,8 @@ package io.apibuilder.api.v0 {
 
     def batchDownloadApplications: BatchDownloadApplications = BatchDownloadApplications
 
+    def batchVersionsLatest: BatchVersionsLatest = BatchVersionsLatest
+
     def changes: Changes = Changes
 
     def code: Code = Code
@@ -2791,6 +2866,21 @@ package io.apibuilder.api.v0 {
           case r if r.status == 201 => _root_.io.apibuilder.api.v0.Client.parseJson("io.apibuilder.api.v0.models.BatchDownloadApplications", r, _.validate[io.apibuilder.api.v0.models.BatchDownloadApplications])
           case r if r.status == 409 => throw io.apibuilder.api.v0.errors.ErrorsResponse(r)
           case r => throw io.apibuilder.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 201, 409")
+        }
+      }
+    }
+
+    object BatchVersionsLatest extends BatchVersionsLatest {
+      override def post(
+        orgKey: String,
+        batchVersionsLatestForm: io.apibuilder.api.v0.models.BatchVersionsLatestForm,
+        requestHeaders: Seq[(String, String)] = Nil
+      )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.api.v0.models.BatchVersionsLatest] = {
+        val payload = play.api.libs.json.Json.toJson(batchVersionsLatestForm)
+
+        _executeRequest("POST", s"/${play.utils.UriEncoding.encodePathSegment(orgKey, "UTF-8")}/batch/versions/latest", body = Some(payload), requestHeaders = requestHeaders).map {
+          case r if r.status == 200 => _root_.io.apibuilder.api.v0.Client.parseJson("io.apibuilder.api.v0.models.BatchVersionsLatest", r, _.validate[io.apibuilder.api.v0.models.BatchVersionsLatest])
+          case r => throw io.apibuilder.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
       }
     }
@@ -3853,6 +3943,7 @@ package io.apibuilder.api.v0 {
       def attributes: io.apibuilder.api.v0.Attributes
       def authentications: io.apibuilder.api.v0.Authentications
       def batchDownloadApplications: io.apibuilder.api.v0.BatchDownloadApplications
+      def batchVersionsLatest: io.apibuilder.api.v0.BatchVersionsLatest
       def changes: io.apibuilder.api.v0.Changes
       def code: io.apibuilder.api.v0.Code
       def domains: io.apibuilder.api.v0.Domains
@@ -4024,6 +4115,17 @@ package io.apibuilder.api.v0 {
       batchDownloadApplicationsForm: io.apibuilder.api.v0.models.BatchDownloadApplicationsForm,
       requestHeaders: Seq[(String, String)] = Nil
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.api.v0.models.BatchDownloadApplications]
+  }
+
+  trait BatchVersionsLatest {
+    /**
+     * Retrieve the latest version for multiple applications in one API call.
+     */
+    def post(
+      orgKey: String,
+      batchVersionsLatestForm: io.apibuilder.api.v0.models.BatchVersionsLatestForm,
+      requestHeaders: Seq[(String, String)] = Nil
+    )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[io.apibuilder.api.v0.models.BatchVersionsLatest]
   }
 
   trait Changes {

--- a/spec/apibuilder-api.json
+++ b/spec/apibuilder-api.json
@@ -546,6 +546,29 @@
         { "name": "application_key", "type": "string" },
         { "name": "version", "type": "string", "default": "latest", "required": false }
       ]
+    },
+
+    "batch_versions_latest_form": {
+      "description": "Form to request the latest version for multiple applications in a single API call.",
+      "fields": [
+        { "name": "application_keys", "type": "[string]", "description": "List of application keys to look up" }
+      ]
+    },
+
+    "batch_version_latest": {
+      "description": "The latest version for a single application, if any versions exist.",
+      "fields": [
+        { "name": "application_key", "type": "string" },
+        { "name": "latest_version", "type": "string", "required": false, "description": "The latest version string, or absent if no versions exist for this application" }
+      ]
+    },
+
+    "batch_versions_latest": {
+      "plural": "batch_versions_latest",
+      "description": "Response containing the latest version for each requested application.",
+      "fields": [
+        { "name": "applications", "type": "[batch_version_latest]" }
+      ]
     }
   },
 
@@ -1004,6 +1027,20 @@
           "responses": {
             "201": { "type": "batch_download_applications" },
             "409": { "type": "[error]" }
+          }
+        }
+      ]
+    },
+
+    "batch_versions_latest": {
+      "path": "/:orgKey/batch/versions/latest",
+      "operations": [
+        {
+          "method": "POST",
+          "description": "Retrieve the latest version for multiple applications in one API call.",
+          "body": { "type": "batch_versions_latest_form" },
+          "responses": {
+            "200": { "type": "batch_versions_latest" }
           }
         }
       ]


### PR DESCRIPTION
## Summary
- Adds `POST /:orgKey/batch/versions/latest` endpoint that returns the latest version for multiple applications in a single request
- Uses efficient PostgreSQL `DISTINCT ON` query instead of N sequential lookups
- Includes input size limit (500 keys max) and proper soft-delete filtering

## Test plan
- [x] 5 new controller tests covering existing apps, non-existent apps, mixed, multiple, and empty list
- [x] Full test suite passes (709 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)