### PR TITLE
Remove version suffix from generated namespaces

### DIFF
--- a/lib/src/main/scala/ServiceConfiguration.scala
+++ b/lib/src/main/scala/ServiceConfiguration.scala
@@ -12,14 +12,13 @@ case class ServiceConfiguration(
   private val ApplicationNamespaceNonLetterRegexp = """\.([^a-zA-Z])""".r
 
   /**
-    * Example: apidocSpec => apidoc.spec.v0
+    * Example: apidocSpec => apidoc.spec
     */
   def applicationNamespace(key: String): String = {
     ApplicationNamespaceNonLetterRegexp.replaceAllIn(
       (
         Seq(orgNamespace.trim) ++
-        Text.splitIntoWords(Text.camelCaseToUnderscore(key.trim)).map(_.toLowerCase).map(_.trim) ++
-        Seq(VersionTag(version).major.map(num => s"v$num").getOrElse(""))
+        Text.splitIntoWords(Text.camelCaseToUnderscore(key.trim)).map(_.toLowerCase).map(_.trim)
       ).filter(!_.isEmpty).mkString("."),
       m => m.group(1)
     )

--- a/lib/src/test/scala/ServiceConfigurationSpec.scala
+++ b/lib/src/test/scala/ServiceConfigurationSpec.scala
@@ -10,28 +10,28 @@ class ServiceConfigurationSpec extends AnyFunSpec with Matchers
 
   it("applicationNamespace") {
     val config = makeServiceConfiguration("me.apidoc")
-    config.applicationNamespace("api") should be("me.apidoc.api.v1")
-    config.applicationNamespace("spec") should be("me.apidoc.spec.v1")
-    config.applicationNamespace("fooBar") should be("me.apidoc.foo.bar.v1")
-    config.applicationNamespace("foo-bar") should be("me.apidoc.foo.bar.v1")
-    config.applicationNamespace("foo_bar") should be("me.apidoc.foo.bar.v1")
-    config.applicationNamespace("Foo.bar") should be("me.apidoc.foo.bar.v1")
-    config.applicationNamespace("fooBarBaz") should be("me.apidoc.foo.bar.baz.v1")
+    config.applicationNamespace("api") should be("me.apidoc.api")
+    config.applicationNamespace("spec") should be("me.apidoc.spec")
+    config.applicationNamespace("fooBar") should be("me.apidoc.foo.bar")
+    config.applicationNamespace("foo-bar") should be("me.apidoc.foo.bar")
+    config.applicationNamespace("foo_bar") should be("me.apidoc.foo.bar")
+    config.applicationNamespace("Foo.bar") should be("me.apidoc.foo.bar")
+    config.applicationNamespace("fooBarBaz") should be("me.apidoc.foo.bar.baz")
   }
 
   it("applicationNamespace is in lower case") {
     val config = makeServiceConfiguration("ME.APIDOC")
-    config.applicationNamespace("API") should be("ME.APIDOC.api.v1")
+    config.applicationNamespace("API") should be("ME.APIDOC.api")
   }
 
   it("applicationNamespace is trimmed") {
     val config = makeServiceConfiguration("me.apidoc")
-    config.applicationNamespace("  api  ") should be("me.apidoc.api.v1")
+    config.applicationNamespace("  api  ") should be("me.apidoc.api")
   }
 
   it("applicationNamespace with numbers") {
     val config = makeServiceConfiguration("io.apibuilder")
-    config.applicationNamespace("mercury-3pl") should be("io.apibuilder.mercury3pl.v1")
+    config.applicationNamespace("mercury-3pl") should be("io.apibuilder.mercury3pl")
   }
 
 }


### PR DESCRIPTION
## Summary
- Remove version suffix (`.v0`, `.v1`, etc.) from `ServiceConfiguration.applicationNamespace()` 
- Namespaces like `com.bryzek.chat.v0` now become `com.bryzek.chat`
- Tests updated to match new behavior

## Test plan
- [x] All 64 lib tests pass
- [ ] Verify downstream codegen produces correct namespaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)