### PR TITLE
FDN-4939: Download environment-provider.jar in Dockerfile runtime stage

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /opt/play
 RUN sbt 'project api' clean stage
 
 FROM flowcommerce/play_java17:latest
+RUN wget -q https://cdn.flow.io/util/environment-provider/environment-provider.jar -O /root/environment-provider.jar
 COPY --from=builder /opt/play /opt/play
 WORKDIR /opt/play/api/target/universal/stage
 ENTRYPOINT ["java", "-jar", "/root/environment-provider.jar", "--service", "play", "apibuilder-api", "bin/apibuilder-api"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /opt/play
 RUN sbt 'project api' clean stage
 
 FROM flowcommerce/play_java17:latest
-RUN wget -q https://cdn.flow.io/util/environment-provider/environment-provider.jar -O /root/environment-provider.jar
+RUN wget -q https://cdn.flow.io/util/environment-provider/environment-provider.jar -O /root/environment-provider.jar && test -s /root/environment-provider.jar
 COPY --from=builder /opt/play /opt/play
 WORKDIR /opt/play/api/target/universal/stage
 ENTRYPOINT ["java", "-jar", "/root/environment-provider.jar", "--service", "play", "apibuilder-api", "bin/apibuilder-api"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /opt/play
 RUN sbt 'project app' clean stage
 
 FROM flowcommerce/play_java17:latest
-RUN wget -q https://cdn.flow.io/util/environment-provider/environment-provider.jar -O /root/environment-provider.jar
+RUN wget -q https://cdn.flow.io/util/environment-provider/environment-provider.jar -O /root/environment-provider.jar && test -s /root/environment-provider.jar
 COPY --from=builder /opt/play /opt/play
 WORKDIR /opt/play/app/target/universal/stage
 ENTRYPOINT ["java", "-jar", "/root/environment-provider.jar", "--service", "play", "apibuilder-app", "bin/apibuilder-app"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /opt/play
 RUN sbt 'project app' clean stage
 
 FROM flowcommerce/play_java17:latest
+RUN wget -q https://cdn.flow.io/util/environment-provider/environment-provider.jar -O /root/environment-provider.jar
 COPY --from=builder /opt/play /opt/play
 WORKDIR /opt/play/app/target/universal/stage
 ENTRYPOINT ["java", "-jar", "/root/environment-provider.jar", "--service", "play", "apibuilder-app", "bin/apibuilder-app"]


### PR DESCRIPTION
## Summary

- [FDN-4939](https://flowio.atlassian.net/browse/FDN-4939)
- The `environment-provider.jar` was removed from the `flowcommerce/play_builder_java17` image in [flowcommerce/docker@458061b](https://github.com/flowcommerce/docker/commit/458061bb8a7aeb6098f3af91accc2bda443fae9e), breaking image builds that rely on it at runtime.
- Both `api/Dockerfile` and `app/Dockerfile` now download the jar directly in the runtime stage, removing the dependency on the builder image bundling it.
- `test -s` ensures a failed or empty download causes a hard build failure rather than a silent runtime crash.

## Dependencies

None.

## Validation

- [ ] Docker build succeeds for both `api` and `app` images
- [ ] Container starts and `environment-provider.jar` is present at `/root/environment-provider.jar`

## Eng-Review Summary

- Revision: a4f2fa3ee918159f2823664587e964ff22f27f3c
- Timestamp: 2026-05-20T00:00:00Z
- Status: passed_with_notes
- Issues:
  - Tag: CODE_QUALITY
    Title: Unversioned CDN URL — builds not pinned
    Resolution: justified
    Justification: Matches original upstream behaviour in flowcommerce/docker; always fetching latest environment-provider is intentional.
  - Tag: CODE_QUALITY
    Title: wget binary assumed present in base image
    Resolution: justified
    Justification: play_java17 is based on eclipse-temurin:17-jre-jammy (Ubuntu Jammy), which ships wget by default.