### PR TITLE
FDN-4939: Fix NOT IN → NOT EXISTS in ScheduleMigrateVersionsProcessor

### DIFF
--- a/api/app/processor/ScheduleMigrateVersionsProcessor.scala
+++ b/api/app/processor/ScheduleMigrateVersionsProcessor.scala
@@ -28,14 +28,20 @@ class ScheduleMigrateVersionsProcessor @Inject()(
     s"""
       |select v.guid
       |  from versions v
-      |  join applications apps on apps.guid = v.application_guid and apps.deleted_at is null
+      |  join applications apps on apps.guid = v.application_guid
+      |    and apps.deleted_at is null
       |  left join cache.services on services.deleted_at is null
-      |                          and services.version_guid = v.guid
-      |                          and services.version = {service_version}
+      |    and services.version_guid = v.guid
+      |    and services.version = {service_version}
       | where v.deleted_at is null
       |   and services.guid is null
-      |   and v.guid not in (select type_id::uuid from tasks where type = {task_type})
-      |limit $Limit
+      |   and not exists (
+      |     select 1
+      |       from tasks
+      |      where type = {task_type}
+      |        and type_id = v.guid::text
+      |   )
+      | limit $Limit
       |""".stripMargin
   ).bind("service_version", MigrateVersion.ServiceVersionNumber)
     .bind("task_type", TaskType.MigrateVersion.toString)


### PR DESCRIPTION
## Summary

- [FDN-4939](https://flowio.atlassian.net/browse/FDN-4939)
- `ScheduleMigrateVersionsProcessor` was running a query with `NOT IN (SELECT type_id::uuid FROM tasks WHERE type = ...)` that caused ~99% CPU on `apibuilderdb20211217`. Two issues combined to cause the full-table scan:
  1. `type_id::uuid` applied a cast to an indexed column on every subquery row, defeating the index and forcing a full scan of `tasks`.
  2. `NOT IN` materialises the entire subquery before the anti-join, compounding the cost.
- Replaced with `NOT EXISTS` and flipped the cast to `v.guid::text`, so Postgres can seek the existing `unique(type_id, type)` index directly — one targeted lookup per outer row instead of a full scan.

## Dependencies

None. The existing `unique(type_id, type)` index on `tasks` already covers the new predicate; no schema migration needed.

## Validation

- [ ] CPU on `apibuilderdb20211217` drops after deploy
- [ ] `ScheduleMigrateVersionsProcessor` continues to enqueue `MigrateVersion` tasks correctly

## Eng-Review Summary

- Revision: 915bc4abdab222f8ecfab7402746fcf9f3018b6f
- Timestamp: 2026-05-20T14:00:00Z
- Status: passed
- Issues: None